### PR TITLE
Add local OpenAI-compatible providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added first-class local OpenAI-compatible provider adapters for generic local
+  servers, Ollama, llama.cpp server, and LM Studio, including chat, streaming,
+  embeddings, model discovery, routing, health, fallback, usage, and metrics
+  integration through the normal provider path.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
 </p>
 
-**A lightweight, single-binary, self-hosted OpenAI-compatible LLM router that intelligently scavenges free-tier tokens first - with smart fallback to paid providers when you allow it.**
+**A lightweight, single-binary, self-hosted OpenAI-compatible LLM router that intelligently scavenges local and free-tier tokens first - with smart fallback to paid providers when you allow it.**
 
 **Just change the `base_url` in your OpenAI SDK** and TokenScavenger handles the rest: provider credentials, routing logic, model discovery, circuit breakers, usage tracking, and a beautiful operator dashboard - all in one Rust binary backed by SQLite.
 
@@ -22,9 +22,9 @@
                             ┌───────────────────────────────┤
                             ↓                               ↓
                     ┌──────────────┐              ┌──────────────────┐
-                    │  Groq (free)  │              │  Gemini (free)   │
+                    │ Local/Ollama  │              │  Gemini (free)   │
                     ├──────────────┤              ├──────────────────┤
-                    │ Cerebras     │              │ OpenRouter       │
+                    │ Groq         │              │ OpenRouter       │
                     │ Mistral      │              │ Cloudflare       │
                     │ NVIDIA NIM   │              │ GitHub Models    │
                     │ HuggingFace  │              │ SiliconFlow      │
@@ -34,7 +34,7 @@
 
 ## Why TokenScavenger?
 
-- **Maximize free inference** across 14 permanent free-tier providers without managing dozens of API endpoints.
+- **Maximize local and free inference** across local OpenAI-compatible servers and permanent free-tier providers without managing dozens of API endpoints.
 - **Zero runtime overhead** — one static binary, no Docker or Python/Node required for basic use.
 - **Production-grade resilience** — circuit breakers, health checks, retries, and full observability.
 - **Beautiful built-in UI** — monitor usage, routing decisions, and provider health in real time.
@@ -46,7 +46,7 @@
 - **Tool-aware routing** for agentic clients, preferring stronger tool-call
   providers automatically when OpenAI `tools` are present
 - **Full OpenAI-compatible API** (chat completions + streaming SSE, embeddings, `/v1/models`)
-- **14 built-in providers** with automatic model discovery
+- **18 built-in providers** with automatic model discovery, including local OpenAI-compatible upstreams
 - **Circuit breakers, retries & health monitoring**
 - **Prometheus metrics** + per-provider token usage tracking
 - **Embedded web UI** with live dashboard, logs, and config editor
@@ -197,7 +197,7 @@ src/
   db/           SQLite pool, migrations (9 tables), helpers
   discovery/    Model discovery, curated catalog, merge logic
   metrics/      Prometheus counters/histograms, structured tracing
-  providers/    14 provider adapter implementations
+  providers/    18 provider adapter implementations
   resilience/   Circuit breakers, health tracking, retry/backoff
   router/       Route planning engine, policy, model groups, fallback
   ui/           Embedded operator web UI (9 views)

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -33,7 +33,7 @@ allow_paid_fallback = false         # Allow fallback to paid providers
 objective = "balanced"              # min_cost | min_latency | balanced | quality_first | local_only
 default_model_group_strategy = "provider-priority"
 provider_order = [                  # Fallback ordering
-    "groq", "cerebras", "google", "openrouter", "cloudflare",
+    "ollama", "local", "groq", "cerebras", "google", "openrouter", "cloudflare",
     "nvidia", "mistral", "github-models", "siliconflow",
     "huggingface", "cohere", "zai", "deepseek", "xai"
 ]
@@ -132,6 +132,12 @@ operator order.
 Route-plan explanations include the selected objective, score components,
 estimated cost, observed latency, failure rate, and skip reasons.
 
+The `local_only` objective keeps only local attempts. Built-in local provider
+IDs (`local`, `ollama`, `llama-cpp`, and `lmstudio`) always qualify, and any
+provider whose configured `base_url` uses `localhost`, `127.0.0.1`, or `::1`
+also qualifies. Local providers still use the normal adapter, health, breaker,
+fallback, usage, and metrics paths.
+
 For chat requests that include OpenAI `tools`, TokenScavenger applies a
 tool-aware reprioritization pass before policy scoring so agentic workloads and
 Hermes-style coding harnesses prefer providers with stronger tool-call behavior
@@ -161,7 +167,16 @@ This is an array of provider configurations. Each entry specifies:
 | `discover_models` | `true` | Whether to query the provider's model list endpoint. |
 
 Supported provider IDs:
-`groq`, `google`, `openrouter`, `cloudflare`, `cerebras`, `nvidia`, `cohere`, `mistral`, `github-models`, `huggingface`, `zai` (or `zhipu`), `siliconflow`, `deepseek`, `xai` (or `grok`)
+`groq`, `google`, `openrouter`, `cloudflare`, `cerebras`, `nvidia`, `cohere`, `mistral`, `github-models`, `huggingface`, `zai` (or `zhipu`), `siliconflow`, `deepseek`, `xai` (or `grok`), `local`, `ollama`, `llama-cpp` (or `llamacpp`), `lmstudio` (or `lm-studio`)
+
+Local provider defaults:
+
+| Provider | Default base URL | Notes |
+|----------|------------------|-------|
+| `local` | `http://127.0.0.1:1234/v1` | Generic OpenAI-compatible local or LAN upstream. Override `base_url` for your server. |
+| `ollama` | `http://127.0.0.1:11434/v1` | Uses Ollama's OpenAI-compatible endpoints. |
+| `llama-cpp` | `http://127.0.0.1:8080/v1` | Uses the llama.cpp server OpenAI-compatible API. |
+| `lmstudio` | `http://127.0.0.1:1234/v1` | Uses LM Studio's local OpenAI-compatible server. |
 
 ### `[[model_groups]]`
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -100,7 +100,7 @@ free_first = true
 allow_paid_fallback = false
 
 # Provider order defines the fallback chain
-provider_order = ["groq", "cerebras", "google", "openrouter", "cloudflare",
+provider_order = ["ollama", "local", "groq", "cerebras", "google", "openrouter", "cloudflare",
                   "nvidia", "mistral", "github-models", "siliconflow",
                   "huggingface", "cohere", "zai", "deepseek", "xai"]
 
@@ -108,6 +108,12 @@ provider_order = ["groq", "cerebras", "google", "openrouter", "cloudflare",
 max_retries_per_provider = 2
 breaker_failure_threshold = 3
 breaker_cooldown_secs = 60
+
+[[providers]]
+id = "ollama"
+enabled = true
+base_url = "http://127.0.0.1:11434/v1"
+api_key = ""
 
 [[providers]]
 id = "groq"

--- a/documentation/provider-matrix.md
+++ b/documentation/provider-matrix.md
@@ -1,6 +1,6 @@
 # Provider Support Matrix
 
-TokenScavenger ships with 14 built-in provider adapters. This document details each provider's API format, capabilities, free-tier limits, paid fallback behavior, and known quirks.
+TokenScavenger ships with 18 built-in provider adapters. This document details each provider's API format, capabilities, free-tier limits, paid fallback behavior, and known quirks.
 
 ## Legend
 
@@ -15,6 +15,10 @@ TokenScavenger ships with 14 built-in provider adapters. This document details e
 
 | Provider | API Format | Chat | Streaming | Tools | Embeddings | Vision | Free Tier |
 |----------|-----------|------|-----------|-------|------------|--------|-----------|
+| Local OpenAI-Compatible | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
+| Ollama | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
+| llama.cpp Server | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
+| LM Studio | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
 | Groq | OpenAI-compat | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 | Google Gemini | Native | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | OpenRouter | OpenAI-compat | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ (:free suffix) |
@@ -31,6 +35,62 @@ TokenScavenger ships with 14 built-in provider adapters. This document details e
 | xAI (Grok) | OpenAI-compat | ✅ | ✅ | ✅ | ❌ | ✅ | Paid fallback |
 
 ## Provider Details
+
+### Local OpenAI-Compatible
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `http://127.0.0.1:1234/v1` by default; override `base_url` for your server |
+| **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
+| **Chat endpoint** | `POST /chat/completions` |
+| **Embeddings endpoint** | `POST /embeddings` |
+| **Models endpoint** | `GET /models` |
+| **Format** | OpenAI-compatible |
+| **Free models** | Operator-local models |
+| **Quirks** | ⚠️ Capabilities depend on the local server and loaded model. TokenScavenger handles routing, health, fallback, metrics, and normalization, but does not serve models itself. |
+| **Routing** | Use provider ID `local`, or set `[routing].objective = "local_only"` to filter to local upstreams. |
+
+### Ollama
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `http://127.0.0.1:11434/v1` |
+| **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
+| **Chat endpoint** | `POST /chat/completions` |
+| **Embeddings endpoint** | `POST /embeddings` |
+| **Models endpoint** | `GET /models` |
+| **Format** | OpenAI-compatible |
+| **Free models** | Locally pulled Ollama models such as `llama3.2` or `qwen2.5-coder:7b` |
+| **Quirks** | ⚠️ Model availability and tool/JSON/vision behavior depend on locally pulled models and Ollama's compatibility layer. |
+| **Docs** | https://github.com/ollama/ollama/blob/main/docs/openai.md |
+
+### llama.cpp Server
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `http://127.0.0.1:8080/v1` |
+| **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
+| **Chat endpoint** | `POST /chat/completions` |
+| **Embeddings endpoint** | `POST /embeddings` |
+| **Models endpoint** | `GET /models` |
+| **Format** | OpenAI-compatible |
+| **Free models** | The model loaded by the local llama.cpp server |
+| **Quirks** | ⚠️ Capabilities depend on server flags and the loaded model. |
+| **Docs** | https://github.com/ggml-org/llama.cpp/tree/master/tools/server |
+
+### LM Studio
+
+| Property | Value |
+|----------|-------|
+| **Base URL** | `http://127.0.0.1:1234/v1` |
+| **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
+| **Chat endpoint** | `POST /chat/completions` |
+| **Embeddings endpoint** | `POST /embeddings` |
+| **Models endpoint** | `GET /models` |
+| **Format** | OpenAI-compatible |
+| **Free models** | The model selected in LM Studio's local server |
+| **Quirks** | ⚠️ Capabilities depend on the selected local model. |
+| **Docs** | https://lmstudio.ai/docs/app/api/endpoints/openai |
 
 ### Groq
 

--- a/src/discovery/curated.rs
+++ b/src/discovery/curated.rs
@@ -171,6 +171,33 @@ pub fn curated_catalog() -> Vec<DiscoveredModel> {
             context_window: Some(2_000_000),
             free_tier: false,
         },
+        // Local OpenAI-compatible providers. These are conservative examples;
+        // dynamic discovery and operator-configured model rows remain the source
+        // of truth for what is actually loaded on the workstation.
+        DiscoveredModel {
+            provider_id: "ollama".into(),
+            upstream_model_id: "llama3.2".into(),
+            display_name: Some("Llama 3.2 (Ollama)".into()),
+            endpoint_compatibility: vec!["chat".into()],
+            context_window: None,
+            free_tier: true,
+        },
+        DiscoveredModel {
+            provider_id: "ollama".into(),
+            upstream_model_id: "qwen2.5-coder:7b".into(),
+            display_name: Some("Qwen2.5 Coder 7B (Ollama)".into()),
+            endpoint_compatibility: vec!["chat".into()],
+            context_window: None,
+            free_tier: true,
+        },
+        DiscoveredModel {
+            provider_id: "local".into(),
+            upstream_model_id: "local-model".into(),
+            display_name: Some("Local Model".into()),
+            endpoint_compatibility: vec!["chat".into()],
+            context_window: None,
+            free_tier: true,
+        },
     ]
 }
 
@@ -180,11 +207,19 @@ pub fn curated_catalog() -> Vec<DiscoveredModel> {
 pub async fn seed_curated_models(db: &sqlx::SqlitePool) {
     let catalog = curated_catalog();
     for model in &catalog {
+        let supports_chat = model
+            .endpoint_compatibility
+            .iter()
+            .any(|kind| kind == "chat");
+        let supports_embeddings = model
+            .endpoint_compatibility
+            .iter()
+            .any(|kind| kind == "embeddings");
         let _ = sqlx::query(
             "INSERT OR IGNORE INTO models \
-             (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, \
+             (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, supports_embeddings, \
               metadata_json, discovered_at, updated_at) \
-             VALUES (?, ?, ?, 1, ?, 1, ?, datetime('now'), datetime('now'))",
+             VALUES (?, ?, ?, 1, ?, ?, ?, ?, datetime('now'), datetime('now'))",
         )
         .bind(&model.provider_id)
         .bind(&model.upstream_model_id)
@@ -195,6 +230,8 @@ pub async fn seed_curated_models(db: &sqlx::SqlitePool) {
                 .unwrap_or(&model.upstream_model_id),
         )
         .bind(model.free_tier)
+        .bind(supports_chat)
+        .bind(supports_embeddings)
         .bind(serde_json::json!({"context_window": model.context_window}).to_string())
         .execute(db)
         .await;

--- a/src/discovery/refresh.rs
+++ b/src/discovery/refresh.rs
@@ -67,14 +67,21 @@ async fn refresh_one(state: &AppState, provider_cfg: crate::config::schema::Prov
                 .collect::<Vec<_>>();
             let mut stored_count = 0_i64;
             for m in &models_to_store {
+                let supports_chat = m.endpoint_compatibility.iter().any(|kind| kind == "chat");
+                let supports_embeddings = m
+                    .endpoint_compatibility
+                    .iter()
+                    .any(|kind| kind == "embeddings");
                 match sqlx::query(
-                    "INSERT OR REPLACE INTO models (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, metadata_json, discovered_at, updated_at)
-                     VALUES (?, ?, ?, 1, ?, 1, ?, datetime('now'), datetime('now'))"
+                    "INSERT OR REPLACE INTO models (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, supports_embeddings, metadata_json, discovered_at, updated_at)
+                     VALUES (?, ?, ?, 1, ?, ?, ?, ?, datetime('now'), datetime('now'))"
                 )
                 .bind(&m.provider_id)
                 .bind(&m.upstream_model_id)
                 .bind(m.display_name.as_deref().unwrap_or(&m.upstream_model_id))
                 .bind(m.free_tier)
+                .bind(supports_chat)
+                .bind(supports_embeddings)
                 .bind(serde_json::json!({"context_window": m.context_window}).to_string())
                 .execute(&state.db)
                 .await

--- a/src/providers/local.rs
+++ b/src/providers/local.rs
@@ -1,0 +1,152 @@
+use crate::api::openai::chat::{NormalizedChatRequest, ProviderChatResponse};
+use crate::api::openai::embeddings::{NormalizedEmbeddingsRequest, ProviderEmbeddingsResponse};
+use crate::config::schema::ProviderConfig;
+use crate::discovery::curated::DiscoveredModel;
+use crate::providers::http::bearer_auth;
+use crate::providers::normalization::ProviderCapabilities;
+use crate::providers::shared;
+use crate::providers::traits::{
+    AuthKind, EndpointKind, ProviderAdapter, ProviderContext, ProviderError,
+};
+use async_trait::async_trait;
+use reqwest::header::HeaderMap;
+use url::Url;
+
+fn local_capabilities(docs_url: &'static str, quirks: Vec<String>) -> ProviderCapabilities {
+    ProviderCapabilities {
+        openai_compatible: true,
+        has_quirks: true,
+        quirks,
+        supports_streaming: true,
+        supports_tools: true,
+        supports_json_mode: true,
+        supports_vision: false,
+        docs_url: Some(docs_url.into()),
+    }
+}
+
+macro_rules! local_openai_adapter {
+    ($name:ident, $id:expr, $display:expr, $base_url:expr, $docs_url:expr, [$($quirk:expr),+ $(,)?]) => {
+        pub struct $name;
+
+        #[async_trait]
+        impl ProviderAdapter for $name {
+            fn provider_id(&self) -> &'static str {
+                $id
+            }
+
+            fn display_name(&self) -> &'static str {
+                $display
+            }
+
+            fn supports_endpoint(&self, kind: &EndpointKind) -> bool {
+                matches!(
+                    kind,
+                    EndpointKind::ChatCompletions | EndpointKind::Embeddings | EndpointKind::ModelList
+                )
+            }
+
+            fn auth_kind(&self) -> AuthKind {
+                AuthKind::Bearer
+            }
+
+            fn capabilities(&self) -> ProviderCapabilities {
+                local_capabilities($docs_url, vec![$($quirk.into()),+])
+            }
+
+            fn base_url(&self, config: &ProviderConfig) -> Url {
+                shared::provider_base_url($id, config, $base_url)
+            }
+
+            fn default_headers(&self, config: &ProviderConfig) -> HeaderMap {
+                bearer_auth(config)
+            }
+
+            async fn discover_models(
+                &self,
+                ctx: &ProviderContext,
+            ) -> Result<Vec<DiscoveredModel>, ProviderError> {
+                let mut models = shared::openai_discover_models(ctx, $id).await?;
+                for model in &mut models {
+                    if !model.endpoint_compatibility.iter().any(|kind| kind == "embeddings") {
+                        model.endpoint_compatibility.push("embeddings".into());
+                    }
+                }
+                Ok(models)
+            }
+
+            async fn chat_completions(
+                &self,
+                ctx: &ProviderContext,
+                request: NormalizedChatRequest,
+            ) -> Result<ProviderChatResponse, ProviderError> {
+                shared::openai_chat_completions(ctx, request, $id).await
+            }
+
+            async fn embeddings(
+                &self,
+                ctx: &ProviderContext,
+                request: NormalizedEmbeddingsRequest,
+            ) -> Result<ProviderEmbeddingsResponse, ProviderError> {
+                shared::openai_embeddings(ctx, request, $id).await
+            }
+
+            async fn stream_chat_completions(
+                &self,
+                ctx: &ProviderContext,
+                request: NormalizedChatRequest,
+                tx: tokio::sync::mpsc::Sender<crate::api::openai::stream::StreamEvent>,
+            ) -> Result<(), ProviderError> {
+                shared::openai_stream_completions(ctx, request, $id, tx).await
+            }
+        }
+    };
+}
+
+local_openai_adapter!(
+    LocalOpenAiAdapter,
+    "local",
+    "Local OpenAI-Compatible",
+    "http://127.0.0.1:1234/v1",
+    "https://platform.openai.com/docs/api-reference",
+    [
+        "Generic local OpenAI-compatible upstream; override base_url for your server",
+        "Actual tool, JSON mode, vision, and embeddings support depends on the local server and loaded model"
+    ]
+);
+
+local_openai_adapter!(
+    OllamaAdapter,
+    "ollama",
+    "Ollama",
+    "http://127.0.0.1:11434/v1",
+    "https://github.com/ollama/ollama/blob/main/docs/openai.md",
+    [
+        "Uses Ollama's OpenAI-compatible /v1 endpoints",
+        "Model availability depends on locally pulled Ollama models"
+    ]
+);
+
+local_openai_adapter!(
+    LlamaCppAdapter,
+    "llama-cpp",
+    "llama.cpp Server",
+    "http://127.0.0.1:8080/v1",
+    "https://github.com/ggml-org/llama.cpp/tree/master/tools/server",
+    [
+        "Uses the llama.cpp server OpenAI-compatible API",
+        "Capabilities depend on server flags and the loaded model"
+    ]
+);
+
+local_openai_adapter!(
+    LmStudioAdapter,
+    "lmstudio",
+    "LM Studio",
+    "http://127.0.0.1:1234/v1",
+    "https://lmstudio.ai/docs/app/api/endpoints/openai",
+    [
+        "Uses LM Studio's OpenAI-compatible local server",
+        "Capabilities depend on the selected local model"
+    ]
+);

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,6 +1,7 @@
 pub mod google;
 pub mod groq;
 pub mod http;
+pub mod local;
 pub mod normalization;
 pub mod registry;
 pub mod shared;

--- a/src/providers/registry.rs
+++ b/src/providers/registry.rs
@@ -97,6 +97,30 @@ pub const SUPPORTED_PROVIDERS: &[ProviderCatalogEntry] = &[
         default_base_url: "https://api.x.ai/v1",
         free_only_default: false,
     },
+    ProviderCatalogEntry {
+        id: "local",
+        display_name: "Local OpenAI-Compatible",
+        default_base_url: "http://127.0.0.1:1234/v1",
+        free_only_default: true,
+    },
+    ProviderCatalogEntry {
+        id: "ollama",
+        display_name: "Ollama",
+        default_base_url: "http://127.0.0.1:11434/v1",
+        free_only_default: true,
+    },
+    ProviderCatalogEntry {
+        id: "llama-cpp",
+        display_name: "llama.cpp Server",
+        default_base_url: "http://127.0.0.1:8080/v1",
+        free_only_default: true,
+    },
+    ProviderCatalogEntry {
+        id: "lmstudio",
+        display_name: "LM Studio",
+        default_base_url: "http://127.0.0.1:1234/v1",
+        free_only_default: true,
+    },
 ];
 
 /// Registry of all available provider adapters.
@@ -183,6 +207,10 @@ fn create_adapter(id: &str) -> Option<Arc<dyn ProviderAdapter>> {
         )),
         "deepseek" => Some(Arc::new(crate::providers::stub_adapters::DeepSeekAdapter)),
         "xai" | "grok" => Some(Arc::new(crate::providers::stub_adapters::XaiAdapter)),
+        "local" => Some(Arc::new(crate::providers::local::LocalOpenAiAdapter)),
+        "ollama" => Some(Arc::new(crate::providers::local::OllamaAdapter)),
+        "llama-cpp" | "llamacpp" => Some(Arc::new(crate::providers::local::LlamaCppAdapter)),
+        "lmstudio" | "lm-studio" => Some(Arc::new(crate::providers::local::LmStudioAdapter)),
         _ => None,
     }
 }

--- a/src/providers/shared.rs
+++ b/src/providers/shared.rs
@@ -1,6 +1,9 @@
 use crate::api::openai::chat::{
     NormalizedChatRequest, ProviderChatResponse, ProviderUsage, ToolCall,
 };
+use crate::api::openai::embeddings::{
+    EmbeddingData, NormalizedEmbeddingsRequest, ProviderEmbeddingsResponse,
+};
 use crate::config::schema::ProviderConfig;
 use crate::discovery::curated::DiscoveredModel;
 use crate::providers::http::{ProviderHttp, bearer_auth};
@@ -343,6 +346,132 @@ pub async fn openai_discover_models(
         .unwrap_or_default();
 
     Ok(models)
+}
+
+/// Helper to execute an OpenAI-compatible embeddings request.
+pub async fn openai_embeddings(
+    ctx: &ProviderContext,
+    request: NormalizedEmbeddingsRequest,
+    provider_id: &str,
+) -> Result<ProviderEmbeddingsResponse, ProviderError> {
+    let url = with_trailing_slash(&ctx.base_url)
+        .join("embeddings")
+        .map_err(|e| ProviderError::Other(e.to_string()))?;
+
+    let config = ProviderConfig {
+        id: provider_id.into(),
+        api_key: ctx.api_key.clone(),
+        ..Default::default()
+    };
+
+    let mut body = serde_json::json!({
+        "model": request.model,
+        "input": request.input,
+    });
+    if let Some(value) = request.encoding_format.as_ref() {
+        body["encoding_format"] = serde_json::json!(value);
+    }
+    if let Some(value) = request.user.as_ref() {
+        body["user"] = serde_json::json!(value);
+    }
+
+    let start = std::time::Instant::now();
+    let resp = ProviderHttp::post_json(&ctx.client, url, bearer_auth(&config), &body).await?;
+    let latency_ms = start.elapsed().as_millis() as i64;
+    let status = resp.status();
+    let rate_limits = parse_rate_limit_headers(resp.headers());
+    let response_body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| ProviderError::MalformedResponse(e.to_string()))?;
+
+    if !status.is_success() {
+        let msg = response_body
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error");
+        return Err(classify_error_with_rate_limits(
+            status.as_u16(),
+            msg,
+            &rate_limits,
+        ));
+    }
+
+    let model = response_body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&request.model)
+        .to_string();
+
+    let data = response_body
+        .get("data")
+        .and_then(|v| v.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let embedding = item
+                        .get("embedding")?
+                        .as_array()?
+                        .iter()
+                        .filter_map(|value| value.as_f64())
+                        .collect::<Vec<_>>();
+                    Some(EmbeddingData {
+                        object: item
+                            .get("object")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("embedding")
+                            .to_string(),
+                        index: item.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+                        embedding,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if data.is_empty() {
+        return Err(ProviderError::MalformedResponse(
+            "embeddings response contained no embedding vectors".into(),
+        ));
+    }
+
+    let usage = response_body.get("usage").map_or(
+        ProviderUsage {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+            prompt_cache_hit_tokens: None,
+            prompt_cache_miss_tokens: None,
+            reasoning_tokens: None,
+        },
+        |usage| ProviderUsage {
+            prompt_tokens: usage
+                .get("prompt_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+            completion_tokens: usage
+                .get("completion_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+            total_tokens: usage
+                .get("total_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32,
+            prompt_cache_hit_tokens: None,
+            prompt_cache_miss_tokens: None,
+            reasoning_tokens: None,
+        },
+    );
+
+    Ok(ProviderEmbeddingsResponse {
+        provider_id: provider_id.to_string(),
+        model_id: model,
+        data,
+        usage,
+        latency_ms,
+    })
 }
 
 /// Parse a single SSE data line and extract the JSON payload.

--- a/src/router/selection.rs
+++ b/src/router/selection.rs
@@ -559,7 +559,7 @@ async fn spent_today(
 fn is_local_attempt(state: &AppState, attempt: &RouteAttempt) -> bool {
     if matches!(
         attempt.provider_id.as_str(),
-        "local" | "ollama" | "llama-cpp"
+        "local" | "ollama" | "llama-cpp" | "lmstudio"
     ) {
         return true;
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,21 +4,19 @@
 //! for integration and E2E testing.
 
 use axum::{
+    Json, Router,
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Sse},
     routing::{get, post},
-    Json, Router,
 };
 use std::sync::{Arc, Mutex};
-use tokio_stream::StreamExt;
 
 /// Configurable mock provider state.
 #[derive(Clone, Default)]
 pub struct MockProviderState {
     pub delay_ms: u64,
     pub status_code: u16,
-    pub response_body: String,
     pub fail_count: Arc<Mutex<u32>>,
     pub succeed_after: u32,
     pub usage_tokens: (u32, u32),
@@ -30,6 +28,7 @@ pub async fn start_mock_server(state: MockProviderState) -> (String, tokio::task
 
     let app = Router::new()
         .route("/v1/chat/completions", post(chat_handler))
+        .route("/v1/embeddings", post(embeddings_handler))
         .route("/v1/models", get(models_handler))
         .route("/healthz", get(|| async { "ok" }))
         .with_state(state);
@@ -50,7 +49,10 @@ async fn chat_handler(
     State(state): State<Arc<MockProviderState>>,
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
-    let stream = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+    let stream = body
+        .get("stream")
+        .and_then(|s| s.as_bool())
+        .unwrap_or(false);
 
     tokio::time::sleep(std::time::Duration::from_millis(state.delay_ms)).await;
 
@@ -58,8 +60,13 @@ async fn chat_handler(
     let mut fails = state.fail_count.lock().unwrap();
     if *fails < state.succeed_after {
         *fails += 1;
-        let status = StatusCode::from_u16(state.status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        return (status, Json(serde_json::json!({"error": {"message": "mock failure"}}))).into_response();
+        let status =
+            StatusCode::from_u16(state.status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        return (
+            status,
+            Json(serde_json::json!({"error": {"message": "mock failure"}})),
+        )
+            .into_response();
     }
 
     if stream {
@@ -77,32 +84,64 @@ async fn chat_handler(
         };
         Sse::new(stream).into_response()
     } else {
-        (StatusCode::OK, Json(serde_json::json!({
-            "id": "chatcmpl-1",
-            "object": "chat.completion",
-            "created": 1,
-            "model": "test-model",
-            "choices": [{
-                "index": 0,
-                "message": {"role": "assistant", "content": "Mock response"},
-                "finish_reason": "stop"
-            }],
-            "usage": {
-                "prompt_tokens": state.usage_tokens.0,
-                "completion_tokens": state.usage_tokens.1,
-                "total_tokens": state.usage_tokens.0 + state.usage_tokens.1
-            }
-        }))).into_response()
+        (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "id": "chatcmpl-1",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "test-model",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "Mock response"},
+                    "finish_reason": "stop"
+                }],
+                "usage": {
+                    "prompt_tokens": state.usage_tokens.0,
+                    "completion_tokens": state.usage_tokens.1,
+                    "total_tokens": state.usage_tokens.0 + state.usage_tokens.1
+                }
+            })),
+        )
+            .into_response()
     }
 }
 
-async fn models_handler(
-    State(_state): State<Arc<MockProviderState>>,
-) -> impl IntoResponse {
+async fn models_handler(State(_state): State<Arc<MockProviderState>>) -> impl IntoResponse {
     Json(serde_json::json!({
         "object": "list",
         "data": [
             {"id": "test-model", "object": "model", "created": 0, "owned_by": "test-org"}
         ]
     }))
+}
+
+async fn embeddings_handler(
+    State(state): State<Arc<MockProviderState>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    tokio::time::sleep(std::time::Duration::from_millis(state.delay_ms)).await;
+
+    let model = body
+        .get("model")
+        .and_then(|value| value.as_str())
+        .unwrap_or("test-embedding-model");
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "object": "list",
+            "model": model,
+            "data": [{
+                "object": "embedding",
+                "index": 0,
+                "embedding": [0.125, -0.25, 0.5]
+            }],
+            "usage": {
+                "prompt_tokens": state.usage_tokens.0,
+                "total_tokens": state.usage_tokens.0
+            }
+        })),
+    )
+        .into_response()
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,6 +2,8 @@
 //!
 //! Uses the Axum test harness with an ephemeral SQLite database.
 
+mod common;
+
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -1047,6 +1049,10 @@ async fn test_provider_contract_matrix_and_failure_classification() {
         "siliconflow",
         "deepseek",
         "xai",
+        "local",
+        "ollama",
+        "llama-cpp",
+        "lmstudio",
     ];
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     let mut config = Config::default();
@@ -1101,6 +1107,67 @@ async fn test_provider_contract_matrix_and_failure_classification() {
         tokenscavenger::providers::shared::classify_error(500, "boom"),
         ProviderError::Other(_)
     ));
+}
+
+#[tokio::test]
+async fn test_local_openai_adapter_supports_embeddings() {
+    let (base_url, handle) = common::start_mock_server(common::MockProviderState {
+        usage_tokens: (3, 0),
+        ..Default::default()
+    })
+    .await;
+
+    let adapter = tokenscavenger::providers::local::LocalOpenAiAdapter;
+    let config = tokenscavenger::config::schema::ProviderConfig {
+        id: "local".into(),
+        enabled: true,
+        base_url: Some(format!("{base_url}/v1")),
+        api_key: None,
+        free_only: true,
+        discover_models: true,
+    };
+    let ctx = tokenscavenger::providers::traits::ProviderContext {
+        base_url: tokenscavenger::providers::traits::ProviderAdapter::base_url(&adapter, &config),
+        api_key: None,
+        config: std::sync::Arc::new(config),
+        client: reqwest::Client::new(),
+    };
+
+    assert!(
+        tokenscavenger::providers::traits::ProviderAdapter::supports_endpoint(
+            &adapter,
+            &tokenscavenger::providers::traits::EndpointKind::Embeddings,
+        )
+    );
+    let models =
+        tokenscavenger::providers::traits::ProviderAdapter::discover_models(&adapter, &ctx)
+            .await
+            .unwrap();
+    assert!(
+        models[0]
+            .endpoint_compatibility
+            .contains(&"embeddings".to_string())
+    );
+
+    let response = tokenscavenger::providers::traits::ProviderAdapter::embeddings(
+        &adapter,
+        &ctx,
+        tokenscavenger::api::openai::embeddings::NormalizedEmbeddingsRequest {
+            model: "local-embed".into(),
+            input: vec!["hello".into()],
+            encoding_format: None,
+            user: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(response.provider_id, "local");
+    assert_eq!(response.model_id, "local-embed");
+    assert_eq!(response.data[0].embedding, vec![0.125, -0.25, 0.5]);
+    assert_eq!(response.usage.prompt_tokens, 3);
+
+    handle.abort();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Add first-class local OpenAI-compatible provider adapters for `local`, `ollama`, `llama-cpp`, and `lmstudio`.
- Reuse the normal provider adapter path for chat, streaming, embeddings, model discovery, health, fallback, usage, and metrics.
- Preserve local routing semantics by treating `lmstudio` as local alongside localhost base URLs and the existing local IDs.
- Update README, configuration docs, getting-started examples, provider matrix, and changelog.

## Why
TokenScavenger owns provider routing, health checks, fallback, metrics, and generic OpenAI-compatible upstream normalization. Local provider support should fit that model without adding a first-party inference engine to the binary.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`

## Notes
- `.dev` implementation notes were updated locally per project guidance, but intentionally not committed because `.dev/` is ignored and the user explicitly requested not to commit `.dev` files.