### PR TITLE
Fix local embedding capability routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added first-class local OpenAI-compatible provider adapters for generic local
   servers, Ollama, llama.cpp server, and LM Studio, including chat, streaming,
-  embeddings, model discovery, routing, health, fallback, usage, and metrics
-  integration through the normal provider path.
+  probed/configurable embeddings, model discovery, routing, health, fallback,
+  usage, and metrics integration through the normal provider path.
 
 ### Changed
 
 ### Fixed
+
+- Fixed route planning so persisted per-model endpoint capabilities are enforced
+  for chat, streaming, and embeddings routes.
+- Fixed Prometheus build metadata to report the running package version instead
+  of hard-coded v0.1.0 labels.
 
 ## [0.2.0] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -13,24 +13,9 @@
 
 **Just change the `base_url` in your OpenAI SDK** and TokenScavenger handles the rest: provider credentials, routing logic, model discovery, circuit breakers, usage tracking, and a beautiful operator dashboard - all in one Rust binary backed by SQLite.
 
-```text
-┌─────────────┐     POST /v1/chat/completions     ┌────────────────┐
-│  Your App   │ ──────────────────────────────────→│ TokenScavenger │
-│ (OpenAI SDK)│                                     │   :8000        │
-│             │←──── OpenAI-shaped responses ──────│                │
-└─────────────┘                                     └───────┬────────┘
-                            ┌───────────────────────────────┤
-                            ↓                               ↓
-                    ┌──────────────┐              ┌──────────────────┐
-                    │ Local/Ollama  │              │  Gemini (free)   │
-                    ├──────────────┤              ├──────────────────┤
-                    │ Groq         │              │ OpenRouter       │
-                    │ Mistral      │              │ Cloudflare       │
-                    │ NVIDIA NIM   │              │ GitHub Models    │
-                    │ HuggingFace  │              │ SiliconFlow      │
-                    │ ZAI/Zhipu    │              │ Cohere           │
-                    └──────────────┘              └──────────────────┘
-```
+<p align="center">
+  <img src="resources/ArchitectureDiagram.svg" alt="TokenScavenger architecture diagram showing OpenAI SDK clients routing through TokenScavenger to local, free-tier, and allowed paid providers" width="960">
+</p>
 
 ## Why TokenScavenger?
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -66,6 +66,7 @@ base_url = ""                       # Override default API endpoint
 api_key = "${GROQ_API_KEY}"         # API key (supports env expansion)
 free_only = true                    # Mark as free-tier
 discover_models = true              # Auto-discover available models
+embedding_support = "auto"          # auto | enabled | disabled for local embeddings
 
 # Model groups for simplified model routing
 [[model_groups]]
@@ -165,6 +166,7 @@ This is an array of provider configurations. Each entry specifies:
 | `api_key` | `""` | API key. Supports `${ENV_VAR}` expansion. |
 | `free_only` | `true` | If `false`, this provider can be used for paid fallback. |
 | `discover_models` | `true` | Whether to query the provider's model list endpoint. |
+| `embedding_support` | `"auto"` | For local OpenAI-compatible providers, controls whether discovered models are marked embedding-capable: `"auto"` probes `/embeddings`, `"enabled"` trusts the operator override, and `"disabled"` suppresses embeddings. Remote providers ignore this field. |
 
 Supported provider IDs:
 `groq`, `google`, `openrouter`, `cloudflare`, `cerebras`, `nvidia`, `cohere`, `mistral`, `github-models`, `huggingface`, `zai` (or `zhipu`), `siliconflow`, `deepseek`, `xai` (or `grok`), `local`, `ollama`, `llama-cpp` (or `llamacpp`), `lmstudio` (or `lm-studio`)
@@ -177,6 +179,18 @@ Local provider defaults:
 | `ollama` | `http://127.0.0.1:11434/v1` | Uses Ollama's OpenAI-compatible endpoints. |
 | `llama-cpp` | `http://127.0.0.1:8080/v1` | Uses the llama.cpp server OpenAI-compatible API. |
 | `lmstudio` | `http://127.0.0.1:1234/v1` | Uses LM Studio's local OpenAI-compatible server. |
+
+Local embeddings are intentionally model-aware. With the default
+`embedding_support = "auto"`, TokenScavenger probes each discovered local model
+against `/embeddings` before advertising embeddings support in `/v1/models` or
+using that model for embedding routes. Use `"enabled"` when a local server blocks
+or dislikes probes but you know the model supports embeddings, and `"disabled"`
+when the local server is chat-only.
+
+Discovery refresh runs in the normal background discovery loop. Local embedding
+probes are bounded to four concurrent probe requests with a short per-model
+timeout, so a large local catalog or unsupported embedding endpoint does not
+serially stall the refresh cycle.
 
 ### `[[model_groups]]`
 

--- a/documentation/provider-matrix.md
+++ b/documentation/provider-matrix.md
@@ -15,10 +15,10 @@ TokenScavenger ships with 18 built-in provider adapters. This document details e
 
 | Provider | API Format | Chat | Streaming | Tools | Embeddings | Vision | Free Tier |
 |----------|-----------|------|-----------|-------|------------|--------|-----------|
-| Local OpenAI-Compatible | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
-| Ollama | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
-| llama.cpp Server | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
-| LM Studio | OpenAI-compat | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ |
+| Local OpenAI-Compatible | OpenAI-compat | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ |
+| Ollama | OpenAI-compat | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ |
+| llama.cpp Server | OpenAI-compat | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ |
+| LM Studio | OpenAI-compat | ✅ | ✅ | ⚠️ | ⚠️ | ⚠️ | ✅ |
 | Groq | OpenAI-compat | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 | Google Gemini | Native | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | OpenRouter | OpenAI-compat | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ (:free suffix) |
@@ -43,11 +43,11 @@ TokenScavenger ships with 18 built-in provider adapters. This document details e
 | **Base URL** | `http://127.0.0.1:1234/v1` by default; override `base_url` for your server |
 | **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
 | **Chat endpoint** | `POST /chat/completions` |
-| **Embeddings endpoint** | `POST /embeddings` |
+| **Embeddings endpoint** | `POST /embeddings`, advertised per discovered model after `embedding_support` probing or operator override |
 | **Models endpoint** | `GET /models` |
 | **Format** | OpenAI-compatible |
 | **Free models** | Operator-local models |
-| **Quirks** | ⚠️ Capabilities depend on the local server and loaded model. TokenScavenger handles routing, health, fallback, metrics, and normalization, but does not serve models itself. |
+| **Quirks** | ⚠️ Capabilities depend on the local server and loaded model. TokenScavenger handles routing, health, fallback, metrics, and normalization, but does not serve models itself. Local embeddings default to probing; set `embedding_support = "enabled"` or `"disabled"` to override. |
 | **Routing** | Use provider ID `local`, or set `[routing].objective = "local_only"` to filter to local upstreams. |
 
 ### Ollama
@@ -57,11 +57,11 @@ TokenScavenger ships with 18 built-in provider adapters. This document details e
 | **Base URL** | `http://127.0.0.1:11434/v1` |
 | **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
 | **Chat endpoint** | `POST /chat/completions` |
-| **Embeddings endpoint** | `POST /embeddings` |
+| **Embeddings endpoint** | `POST /embeddings`, advertised only after probing or override |
 | **Models endpoint** | `GET /models` |
 | **Format** | OpenAI-compatible |
 | **Free models** | Locally pulled Ollama models such as `llama3.2` or `qwen2.5-coder:7b` |
-| **Quirks** | ⚠️ Model availability and tool/JSON/vision behavior depend on locally pulled models and Ollama's compatibility layer. |
+| **Quirks** | ⚠️ Model availability and tool/JSON/vision/embedding behavior depend on locally pulled models and Ollama's compatibility layer. |
 | **Docs** | https://github.com/ollama/ollama/blob/main/docs/openai.md |
 
 ### llama.cpp Server
@@ -71,7 +71,7 @@ TokenScavenger ships with 18 built-in provider adapters. This document details e
 | **Base URL** | `http://127.0.0.1:8080/v1` |
 | **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
 | **Chat endpoint** | `POST /chat/completions` |
-| **Embeddings endpoint** | `POST /embeddings` |
+| **Embeddings endpoint** | `POST /embeddings`, advertised only after probing or override |
 | **Models endpoint** | `GET /models` |
 | **Format** | OpenAI-compatible |
 | **Free models** | The model loaded by the local llama.cpp server |
@@ -85,7 +85,7 @@ TokenScavenger ships with 18 built-in provider adapters. This document details e
 | **Base URL** | `http://127.0.0.1:1234/v1` |
 | **Auth** | Optional `Authorization: Bearer <key>` when `api_key` is configured |
 | **Chat endpoint** | `POST /chat/completions` |
-| **Embeddings endpoint** | `POST /embeddings` |
+| **Embeddings endpoint** | `POST /embeddings`, advertised only after probing or override |
 | **Models endpoint** | `GET /models` |
 | **Format** | OpenAI-compatible |
 | **Free models** | The model selected in LM Studio's local server |

--- a/resources/ArchitectureDiagram.svg
+++ b/resources/ArchitectureDiagram.svg
@@ -1,0 +1,137 @@
+<svg xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc" viewBox="0 0 1280 720">
+  <title id="title">TokenScavenger architecture</title>
+  <desc id="desc">An OpenAI SDK client sends requests to TokenScavenger, which routes through policy, health, model discovery, metrics, and adapter layers to local, free-tier, and paid fallback providers.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#020617"/>
+      <stop offset="0.52" stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#111827"/>
+    </linearGradient>
+    <linearGradient id="fox" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fb923c"/>
+      <stop offset="0.55" stop-color="#f97316"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+    <linearGradient id="emerald" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#34d399"/>
+      <stop offset="1" stop-color="#059669"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1e293b" stop-opacity="0.92"/>
+      <stop offset="1" stop-color="#0f172a" stop-opacity="0.92"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-30%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#020617" flood-opacity="0.45"/>
+    </filter>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <marker id="arrowOrange" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#fb923c"/>
+    </marker>
+    <marker id="arrowEmerald" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#34d399"/>
+    </marker>
+    <style>
+      .label { font-family: Arial, Helvetica, sans-serif; fill: #f8fafc; }
+      .muted { fill: #94a3b8; }
+      .small { font-size: 22px; }
+      .tiny { font-size: 17px; }
+      .title { font-size: 32px; font-weight: 800; letter-spacing: .02em; }
+      .section { font-size: 24px; font-weight: 750; }
+      .pill { font-size: 15px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+      .card { fill: url(#panel); stroke: #334155; stroke-width: 1.5; }
+      .orangeStroke { stroke: #fb923c; }
+      .emeraldStroke { stroke: #34d399; }
+      .dash { stroke-dasharray: 9 11; }
+    </style>
+  </defs>
+
+  <rect width="1280" height="720" rx="36" fill="url(#bg)"/>
+  <circle cx="1090" cy="120" r="210" fill="#f97316" opacity="0.10"/>
+  <circle cx="230" cy="620" r="230" fill="#10b981" opacity="0.08"/>
+  <path d="M80 124 C260 40 412 88 590 122 C765 155 907 77 1200 98" fill="none" stroke="#fb923c" stroke-width="2" opacity="0.18"/>
+  <path d="M70 617 C300 560 437 660 655 604 C832 558 1006 609 1212 542" fill="none" stroke="#34d399" stroke-width="2" opacity="0.16"/>
+
+  <g transform="translate(70 58)">
+    <text class="label title" x="0" y="0">Token<tspan fill="#f97316">Scavenger</tspan> Architecture</text>
+    <text class="label muted small" x="0" y="34">One OpenAI-compatible gateway for local-first routing, fallback, health, metrics, and usage.</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect class="card" x="70" y="210" width="215" height="155" rx="26"/>
+    <text class="label section" x="100" y="260">Your App</text>
+    <text class="label muted small" x="100" y="296">OpenAI SDK</text>
+    <rect x="100" y="318" width="140" height="34" rx="17" fill="#0f172a" stroke="#334155"/>
+    <text class="label tiny" x="118" y="341">base_url swap</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect x="450" y="160" width="380" height="300" rx="34" fill="#111827" stroke="#fb923c" stroke-width="2.2"/>
+    <circle cx="505" cy="216" r="34" fill="url(#fox)" filter="url(#glow)"/>
+    <path d="M486 208 L499 187 L512 208 L532 202 L521 228 L505 238 L489 228 Z" fill="#fff7ed" opacity=".92"/>
+    <path d="M498 217 L505 229 L512 217 Z" fill="#111827"/>
+    <text class="label title" x="552" y="220">TokenScavenger</text>
+    <text class="label muted small" x="552" y="252">single Rust binary :8000</text>
+
+    <g transform="translate(486 292)">
+      <rect x="0" y="0" width="146" height="42" rx="21" fill="#1e293b" stroke="#475569"/>
+      <text class="label tiny" x="21" y="27">Policy engine</text>
+      <rect x="166" y="0" width="146" height="42" rx="21" fill="#1e293b" stroke="#475569"/>
+      <text class="label tiny" x="188" y="27">Health checks</text>
+      <rect x="0" y="58" width="146" height="42" rx="21" fill="#1e293b" stroke="#475569"/>
+      <text class="label tiny" x="24" y="85">Model catalog</text>
+      <rect x="166" y="58" width="146" height="42" rx="21" fill="#1e293b" stroke="#475569"/>
+      <text class="label tiny" x="188" y="85">Fallback plan</text>
+    </g>
+    <rect x="518" y="414" width="244" height="34" rx="17" fill="#064e3b" stroke="#10b981" opacity=".9"/>
+    <text class="label tiny" x="552" y="436">SQLite + Prometheus + UI</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect class="card" x="980" y="102" width="230" height="142" rx="26"/>
+    <rect x="1008" y="126" width="95" height="28" rx="14" fill="#064e3b" stroke="#10b981"/>
+    <text class="label pill" x="1024" y="146">Local</text>
+    <text class="label section" x="1008" y="186">Ollama</text>
+    <text class="label muted tiny" x="1008" y="215">llama.cpp · LM Studio</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect class="card" x="980" y="289" width="230" height="142" rx="26"/>
+    <rect x="1008" y="313" width="120" height="28" rx="14" fill="#1e293b" stroke="#34d399"/>
+    <text class="label pill" x="1024" y="333">Free tier</text>
+    <text class="label section" x="1008" y="373">Groq · Gemini</text>
+    <text class="label muted tiny" x="1008" y="402">Cloudflare · GitHub Models</text>
+  </g>
+
+  <g filter="url(#softShadow)">
+    <rect class="card" x="980" y="476" width="230" height="142" rx="26"/>
+    <rect x="1008" y="500" width="138" height="28" rx="14" fill="#431407" stroke="#fb923c"/>
+    <text class="label pill" x="1024" y="520">Allowed paid</text>
+    <text class="label section" x="1008" y="560">DeepSeek · xAI</text>
+    <text class="label muted tiny" x="1008" y="589">only when policy permits</text>
+  </g>
+
+  <path d="M285 286 C344 286 382 286 432 286" fill="none" stroke="#fb923c" stroke-width="5" marker-end="url(#arrowOrange)" filter="url(#glow)"/>
+  <path d="M450 348 C386 348 346 348 294 348" fill="none" stroke="#34d399" stroke-width="3.5" marker-end="url(#arrowEmerald)"/>
+
+  <path d="M830 246 C890 208 913 176 966 168" fill="none" class="emeraldStroke" stroke-width="4" marker-end="url(#arrowEmerald)"/>
+  <path d="M830 318 C888 321 918 342 966 356" fill="none" class="emeraldStroke" stroke-width="4" marker-end="url(#arrowEmerald)"/>
+  <path d="M830 392 C890 440 922 506 966 542" fill="none" class="orangeStroke dash" stroke-width="4" marker-end="url(#arrowOrange)"/>
+
+  <g transform="translate(78 536)">
+    <rect x="0" y="0" width="310" height="92" rx="24" fill="#020617" opacity=".72" stroke="#334155"/>
+    <text class="label tiny" x="26" y="34">Route decisions are observable:</text>
+    <text class="label muted tiny" x="26" y="62">health · breakers · budgets · metrics · logs</text>
+  </g>
+
+  <g transform="translate(465 514)">
+    <rect x="0" y="0" width="360" height="92" rx="24" fill="#020617" opacity=".72" stroke="#334155"/>
+    <text class="label tiny" x="26" y="34">Provider differences stop at adapters.</text>
+    <text class="label muted tiny" x="26" y="62">Handlers stay OpenAI-compatible.</text>
+  </g>
+</svg>

--- a/src/api/openai/stream.rs
+++ b/src/api/openai/stream.rs
@@ -7,9 +7,9 @@ use crate::providers::traits::{EndpointKind, ProviderContext, ProviderError};
 use crate::router::policy::RoutePolicy;
 use crate::router::selection::{
     TokenEstimate, apply_policy_engine, assign_attempt_priorities, build_attempt_plan_for_target,
-    filter_by_health, filter_by_model_enabled, filter_by_paid_policy, prioritize_for_tool_use,
-    record_context_failure_hint, record_rate_limit_hint, record_stream_silence_hint,
-    should_skip_for_context_hint, should_skip_for_rate_limit_hint,
+    filter_by_health, filter_by_model_enabled_for_endpoint, filter_by_paid_policy,
+    prioritize_for_tool_use, record_context_failure_hint, record_rate_limit_hint,
+    record_stream_silence_hint, should_skip_for_context_hint, should_skip_for_rate_limit_hint,
     should_skip_for_stream_silence_hint,
 };
 use axum::response::sse::Event;
@@ -218,9 +218,10 @@ pub async fn create_chat_stream(
         )));
     }
 
-    let mut plan = filter_by_model_enabled(
+    let mut plan = filter_by_model_enabled_for_endpoint(
         filter_by_paid_policy(filter_by_health(plan, &state), &state),
         &state,
+        EndpointKind::ChatCompletions,
     )
     .await;
     if request.tools.is_some() {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -333,8 +333,8 @@ pub async fn admin_route_plan(
             .get(&attempt.provider_id)
             .map(|b| format!("{:?}", b.state()))
             .unwrap_or_else(|| "Closed".to_string());
-        let model_enabled = sqlx::query_as::<_, (bool,)>(
-            "SELECT enabled FROM models WHERE provider_id = ? AND upstream_model_id = ?",
+        let model_state = sqlx::query_as::<_, (bool, bool, bool)>(
+            "SELECT enabled, supports_chat, supports_embeddings FROM models WHERE provider_id = ? AND upstream_model_id = ?",
         )
         .bind(&attempt.provider_id)
         .bind(&attempt.model_id)
@@ -342,8 +342,13 @@ pub async fn admin_route_plan(
         .await
         .ok()
         .flatten()
-        .map(|row| row.0)
-        .unwrap_or(true);
+        .unwrap_or((true, true, true));
+        let model_enabled = model_state.0;
+        let endpoint_supported = match endpoint_kind {
+            crate::providers::traits::EndpointKind::ChatCompletions => model_state.1,
+            crate::providers::traits::EndpointKind::Embeddings => model_state.2,
+            crate::providers::traits::EndpointKind::ModelList => true,
+        };
         let free_only = config
             .providers
             .iter()
@@ -352,6 +357,7 @@ pub async fn admin_route_plan(
             .unwrap_or(true);
         let paid_allowed = free_only || config.routing.allow_paid_fallback;
         let base_included = model_enabled
+            && endpoint_supported
             && paid_allowed
             && health != "Unhealthy"
             && breaker != "Open"
@@ -361,6 +367,8 @@ pub async fn admin_route_plan(
             None
         } else if !paid_allowed {
             Some("filtered by paid fallback policy")
+        } else if !endpoint_supported {
+            Some("filtered by model endpoint capability")
         } else {
             Some("filtered by health, breaker, or model enablement")
         };
@@ -616,6 +624,17 @@ pub async fn admin_config_save(
                     .and_then(|v| v.as_str())
                     .and_then(|s| if s.is_empty() { None } else { Some(s) });
                 let free_only = provider_update.get("free_only").and_then(|v| v.as_bool());
+                let embedding_support = provider_update
+                    .get("embedding_support")
+                    .and_then(|v| v.as_str())
+                    .and_then(|value| match value {
+                        "auto" => Some(crate::config::schema::ProviderEmbeddingSupport::Auto),
+                        "enabled" => Some(crate::config::schema::ProviderEmbeddingSupport::Enabled),
+                        "disabled" => {
+                            Some(crate::config::schema::ProviderEmbeddingSupport::Disabled)
+                        }
+                        _ => None,
+                    });
                 let is_removal = provider_update
                     .get("remove")
                     .and_then(|v| v.as_bool())
@@ -643,6 +662,9 @@ pub async fn admin_config_save(
                     }
                     if let Some(f) = free_only {
                         provider.free_only = f;
+                    }
+                    if let Some(support) = embedding_support {
+                        provider.embedding_support = support;
                     }
                     // Persist provider state to DB
                     let display_name = &provider.id;
@@ -673,6 +695,7 @@ pub async fn admin_config_save(
                         api_key: api_key.map(String::from),
                         free_only: free_only.unwrap_or(true),
                         discover_models: true,
+                        embedding_support: embedding_support.unwrap_or_default(),
                     };
                     config.providers.push(new_provider);
                     let _ = sqlx::query(

--- a/src/cli/config_cmd.rs
+++ b/src/cli/config_cmd.rs
@@ -341,6 +341,7 @@ fn add_provider(config: &mut Config) -> Result<(), Box<dyn std::error::Error>> {
         api_key: Some(api_key),
         free_only,
         discover_models: true,
+        embedding_support: Default::default(),
     });
 
     println!("  ✓ Provider added");

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -154,6 +154,7 @@ pub fn run_setup_wizard(target_path: &Path) -> Result<Config, Box<dyn std::error
             api_key: Some(api_key),
             free_only,
             discover_models: true,
+            embedding_support: Default::default(),
         });
     }
 

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -39,6 +39,7 @@ pub fn expand_provider_config(
         api_key: cfg.api_key.as_ref().map(|k| expand_env_vars(k)),
         free_only: cfg.free_only,
         discover_models: cfg.discover_models,
+        embedding_support: cfg.embedding_support,
     }
 }
 
@@ -85,6 +86,7 @@ mod tests {
             api_key: None,
             free_only: true,
             discover_models: true,
+            embedding_support: Default::default(),
         };
         let expanded = expand_provider_config(&cfg);
         assert_eq!(expanded.api_key, None);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -210,6 +210,21 @@ pub struct ProviderConfig {
     pub free_only: bool,
     #[serde(default = "default_true")]
     pub discover_models: bool,
+    #[serde(default)]
+    pub embedding_support: ProviderEmbeddingSupport,
+}
+
+/// How OpenAI-compatible local adapters should advertise embeddings support.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderEmbeddingSupport {
+    /// Probe `/embeddings` during discovery before marking a local model as embedding-capable.
+    #[default]
+    Auto,
+    /// Mark discovered models as embedding-capable without probing.
+    Enabled,
+    /// Do not advertise embeddings support for discovered local models.
+    Disabled,
 }
 
 // Default values

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -152,6 +152,7 @@ mod tests {
                     api_key: None,
                     free_only: true,
                     discover_models: true,
+                    embedding_support: Default::default(),
                 },
                 ProviderConfig {
                     id: "groq".into(),
@@ -160,6 +161,7 @@ mod tests {
                     api_key: None,
                     free_only: true,
                     discover_models: true,
+                    embedding_support: Default::default(),
                 },
             ],
             ..Default::default()

--- a/src/metrics/prometheus.rs
+++ b/src/metrics/prometheus.rs
@@ -321,7 +321,9 @@ pub fn render_metrics() -> String {
     writeln!(output, "# TYPE tokenscavenger_build_info gauge").ok();
     writeln!(
         output,
-        "tokenscavenger_build_info{{version=\"0.1.0\",rust=\"1.94.0\"}} 1"
+        "tokenscavenger_build_info{{version=\"{}\",rust=\"{}\"}} 1",
+        env!("CARGO_PKG_VERSION"),
+        option_env!("RUSTC_VERSION").unwrap_or("unknown")
     )
     .ok();
 

--- a/src/providers/local.rs
+++ b/src/providers/local.rs
@@ -1,6 +1,7 @@
 use crate::api::openai::chat::{NormalizedChatRequest, ProviderChatResponse};
 use crate::api::openai::embeddings::{NormalizedEmbeddingsRequest, ProviderEmbeddingsResponse};
 use crate::config::schema::ProviderConfig;
+use crate::config::schema::ProviderEmbeddingSupport;
 use crate::discovery::curated::DiscoveredModel;
 use crate::providers::http::bearer_auth;
 use crate::providers::normalization::ProviderCapabilities;
@@ -9,8 +10,14 @@ use crate::providers::traits::{
     AuthKind, EndpointKind, ProviderAdapter, ProviderContext, ProviderError,
 };
 use async_trait::async_trait;
+use futures::StreamExt;
 use reqwest::header::HeaderMap;
+use std::collections::HashSet;
+use std::time::Duration;
 use url::Url;
+
+const LOCAL_EMBEDDING_PROBE_CONCURRENCY: usize = 4;
+const LOCAL_EMBEDDING_PROBE_TIMEOUT: Duration = Duration::from_millis(1500);
 
 fn local_capabilities(docs_url: &'static str, quirks: Vec<String>) -> ProviderCapabilities {
     ProviderCapabilities {
@@ -23,6 +30,46 @@ fn local_capabilities(docs_url: &'static str, quirks: Vec<String>) -> ProviderCa
         supports_vision: false,
         docs_url: Some(docs_url.into()),
     }
+}
+
+async fn probe_local_embedding_models(
+    ctx: &ProviderContext,
+    provider_id: &'static str,
+    model_ids: Vec<String>,
+) -> HashSet<String> {
+    futures::stream::iter(model_ids)
+        .map(|model_id| async move {
+            let result = tokio::time::timeout(
+                LOCAL_EMBEDDING_PROBE_TIMEOUT,
+                shared::probe_openai_embeddings(ctx, &model_id, provider_id),
+            )
+            .await;
+            match result {
+                Ok(Ok(())) => Some(model_id),
+                Ok(Err(error)) => {
+                    tracing::debug!(
+                        provider = provider_id,
+                        model = %model_id,
+                        error = %error,
+                        "Local embeddings probe did not succeed"
+                    );
+                    None
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        provider = provider_id,
+                        model = %model_id,
+                        timeout_ms = LOCAL_EMBEDDING_PROBE_TIMEOUT.as_millis(),
+                        "Local embeddings probe timed out"
+                    );
+                    None
+                }
+            }
+        })
+        .buffer_unordered(LOCAL_EMBEDDING_PROBE_CONCURRENCY)
+        .filter_map(|model_id| async move { model_id })
+        .collect()
+        .await
 }
 
 macro_rules! local_openai_adapter {
@@ -67,8 +114,27 @@ macro_rules! local_openai_adapter {
                 ctx: &ProviderContext,
             ) -> Result<Vec<DiscoveredModel>, ProviderError> {
                 let mut models = shared::openai_discover_models(ctx, $id).await?;
+                let probed_embedding_models = match ctx.config.embedding_support {
+                    ProviderEmbeddingSupport::Auto => {
+                        let model_ids = models
+                            .iter()
+                            .map(|model| model.upstream_model_id.clone())
+                            .collect::<Vec<_>>();
+                        Some(probe_local_embedding_models(ctx, $id, model_ids).await)
+                    }
+                    _ => None,
+                };
                 for model in &mut models {
-                    if !model.endpoint_compatibility.iter().any(|kind| kind == "embeddings") {
+                    let supports_embeddings = match ctx.config.embedding_support {
+                        ProviderEmbeddingSupport::Enabled => true,
+                        ProviderEmbeddingSupport::Disabled => false,
+                        ProviderEmbeddingSupport::Auto => probed_embedding_models
+                            .as_ref()
+                            .is_some_and(|model_ids| model_ids.contains(&model.upstream_model_id)),
+                    };
+                    if supports_embeddings
+                        && !model.endpoint_compatibility.iter().any(|kind| kind == "embeddings")
+                    {
                         model.endpoint_compatibility.push("embeddings".into());
                     }
                 }

--- a/src/providers/shared.rs
+++ b/src/providers/shared.rs
@@ -380,23 +380,21 @@ pub async fn openai_embeddings(
     let latency_ms = start.elapsed().as_millis() as i64;
     let status = resp.status();
     let rate_limits = parse_rate_limit_headers(resp.headers());
+
+    if !status.is_success() {
+        let body_text = resp.text().await.unwrap_or_default();
+        let msg = extract_error_message(&body_text);
+        return Err(classify_error_with_rate_limits(
+            status.as_u16(),
+            &msg,
+            &rate_limits,
+        ));
+    }
+
     let response_body: serde_json::Value = resp
         .json()
         .await
         .map_err(|e| ProviderError::MalformedResponse(e.to_string()))?;
-
-    if !status.is_success() {
-        let msg = response_body
-            .get("error")
-            .and_then(|e| e.get("message"))
-            .and_then(|m| m.as_str())
-            .unwrap_or("unknown error");
-        return Err(classify_error_with_rate_limits(
-            status.as_u16(),
-            msg,
-            &rate_limits,
-        ));
-    }
 
     let model = response_body
         .get("model")
@@ -472,6 +470,25 @@ pub async fn openai_embeddings(
         usage,
         latency_ms,
     })
+}
+
+pub async fn probe_openai_embeddings(
+    ctx: &ProviderContext,
+    model: &str,
+    provider_id: &str,
+) -> Result<(), ProviderError> {
+    openai_embeddings(
+        ctx,
+        NormalizedEmbeddingsRequest {
+            model: model.to_string(),
+            input: vec!["tokenscavenger embedding capability probe".into()],
+            encoding_format: None,
+            user: None,
+        },
+        provider_id,
+    )
+    .await
+    .map(|_| ())
 }
 
 /// Parse a single SSE data line and extract the JSON payload.
@@ -731,6 +748,22 @@ pub async fn openai_stream_completions(
 /// Classify HTTP status codes into provider errors.
 pub fn classify_error(status: u16, message: &str) -> ProviderError {
     classify_error_with_rate_limits(status, message, &Default::default())
+}
+
+fn extract_error_message(body_text: &str) -> String {
+    if body_text.trim().is_empty() {
+        return "unknown error".into();
+    }
+    serde_json::from_str::<serde_json::Value>(body_text)
+        .ok()
+        .and_then(|body| {
+            body.get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(|message| message.as_str())
+                .or_else(|| body.get("message").and_then(|message| message.as_str()))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| body_text.to_string())
 }
 
 /// Classify HTTP status codes into provider errors with optional rate-limit hints.

--- a/src/router/engine.rs
+++ b/src/router/engine.rs
@@ -9,9 +9,9 @@ use crate::router::fallback::{FallbackDecision, should_fallback};
 use crate::router::policy::RoutePolicy;
 use crate::router::selection::{
     TokenEstimate, apply_policy_engine, assign_attempt_priorities, build_attempt_plan_for_target,
-    filter_by_health, filter_by_model_enabled, filter_by_paid_policy, prioritize_for_tool_use,
-    record_context_failure_hint, record_rate_limit_hint, should_skip_for_context_hint,
-    should_skip_for_rate_limit_hint,
+    filter_by_health, filter_by_model_enabled_for_endpoint, filter_by_paid_policy,
+    prioritize_for_tool_use, record_context_failure_hint, record_rate_limit_hint,
+    should_skip_for_context_hint, should_skip_for_rate_limit_hint,
 };
 use std::sync::Arc;
 use tracing::{info, warn};
@@ -96,9 +96,10 @@ pub async fn route_chat_request(
     }
 
     // Filter by health and breaker state
-    let mut plan = filter_by_model_enabled(
+    let mut plan = filter_by_model_enabled_for_endpoint(
         filter_by_paid_policy(filter_by_health(plan, &state), &state),
         &state,
+        EndpointKind::ChatCompletions,
     )
     .await;
     if request.tools.is_some() {
@@ -523,9 +524,10 @@ pub async fn route_embeddings_request(
         )));
     }
 
-    let plan = filter_by_model_enabled(
+    let plan = filter_by_model_enabled_for_endpoint(
         filter_by_paid_policy(filter_by_health(plan, &state), &state),
         &state,
+        EndpointKind::Embeddings,
     )
     .await;
     let plan = apply_policy_engine(

--- a/src/router/selection.rs
+++ b/src/router/selection.rs
@@ -802,11 +802,20 @@ pub async fn filter_by_model_enabled(
     plan: Vec<RouteAttempt>,
     state: &AppState,
 ) -> Vec<RouteAttempt> {
+    filter_by_model_enabled_for_endpoint(plan, state, EndpointKind::ChatCompletions).await
+}
+
+/// Filter an attempt plan by persisted model enablement and endpoint compatibility.
+pub async fn filter_by_model_enabled_for_endpoint(
+    plan: Vec<RouteAttempt>,
+    state: &AppState,
+    endpoint_kind: EndpointKind,
+) -> Vec<RouteAttempt> {
     let mut filtered = Vec::with_capacity(plan.len());
 
     for attempt in plan {
-        let enabled = sqlx::query_as::<_, (bool,)>(
-            "SELECT enabled FROM models WHERE provider_id = ? AND upstream_model_id = ?",
+        let model_state = sqlx::query_as::<_, (bool, bool, bool)>(
+            "SELECT enabled, supports_chat, supports_embeddings FROM models WHERE provider_id = ? AND upstream_model_id = ?",
         )
         .bind(&attempt.provider_id)
         .bind(&attempt.model_id)
@@ -814,15 +823,30 @@ pub async fn filter_by_model_enabled(
         .await
         .ok()
         .flatten()
-        .map(|row| row.0);
+        .map(|row| {
+            let endpoint_supported = match endpoint_kind {
+                EndpointKind::ChatCompletions => row.1,
+                EndpointKind::Embeddings => row.2,
+                EndpointKind::ModelList => true,
+            };
+            (row.0, endpoint_supported)
+        });
 
-        match enabled {
-            Some(true) => filtered.push(attempt),
-            Some(false) => {
+        match model_state {
+            Some((true, true)) => filtered.push(attempt),
+            Some((false, _)) => {
                 tracing::info!(
                     provider = %attempt.provider_id,
                     model = %attempt.model_id,
                     "Filtered out: model disabled"
+                );
+            }
+            Some((true, false)) => {
+                tracing::info!(
+                    provider = %attempt.provider_id,
+                    model = %attempt.model_id,
+                    endpoint = ?endpoint_kind,
+                    "Filtered out: model does not support requested endpoint"
                 );
             }
             None => {

--- a/src/ui/routes.rs
+++ b/src/ui/routes.rs
@@ -723,6 +723,14 @@ pub async fn render_providers(state: &AppState) -> String {
                         <small>Block paid endpoint use</small>
                     </span>
                 </label>
+                <label class="provider-field">
+                    <span>Embeddings</span>
+                    <select id="new-provider-embedding-support" class="provider-input">
+                        <option value="auto">Auto probe</option>
+                        <option value="enabled">Force on</option>
+                        <option value="disabled">Force off</option>
+                    </select>
+                </label>
                 <button class="btn provider-add-btn" onclick="addProvider()">Add Provider</button>
             </div>
         </div>
@@ -754,8 +762,9 @@ pub async fn render_providers(state: &AppState) -> String {
         const apiKey = document.getElementById('new-provider-key').value.trim();
         const baseUrl = document.getElementById('new-provider-base-url').value.trim();
         const freeOnly = document.getElementById('new-provider-free-only').checked;
+        const embeddingSupport = document.getElementById('new-provider-embedding-support').value;
         if (!apiKey) { showModal('Error', 'API key is required', true); return; }
-        const provider = { id, enabled: true, api_key: apiKey, free_only: freeOnly };
+        const provider = { id, enabled: true, api_key: apiKey, free_only: freeOnly, embedding_support: embeddingSupport };
         if (baseUrl) provider.base_url = baseUrl;
         const r = await fetch('/admin/config', {method:'PUT', headers:{'Content-Type':'application/json'}, body:JSON.stringify({providers:[provider]})});
         if (r.ok) location.reload(); else showModal('Error', 'Provider add failed', true);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,6 +17,9 @@ use std::sync::{Arc, Mutex};
 pub struct MockProviderState {
     pub delay_ms: u64,
     pub status_code: u16,
+    pub embeddings_status_code: u16,
+    pub embeddings_error_body: Option<String>,
+    pub model_ids: Vec<String>,
     pub fail_count: Arc<Mutex<u32>>,
     pub succeed_after: u32,
     pub usage_tokens: (u32, u32),
@@ -107,12 +110,19 @@ async fn chat_handler(
     }
 }
 
-async fn models_handler(State(_state): State<Arc<MockProviderState>>) -> impl IntoResponse {
+async fn models_handler(State(state): State<Arc<MockProviderState>>) -> impl IntoResponse {
+    let model_ids = if state.model_ids.is_empty() {
+        vec!["test-model".to_string()]
+    } else {
+        state.model_ids.clone()
+    };
+    let data = model_ids
+        .into_iter()
+        .map(|id| serde_json::json!({"id": id, "object": "model", "created": 0, "owned_by": "test-org"}))
+        .collect::<Vec<_>>();
     Json(serde_json::json!({
         "object": "list",
-        "data": [
-            {"id": "test-model", "object": "model", "created": 0, "owned_by": "test-org"}
-        ]
+        "data": data
     }))
 }
 
@@ -121,6 +131,24 @@ async fn embeddings_handler(
     Json(body): Json<serde_json::Value>,
 ) -> impl IntoResponse {
     tokio::time::sleep(std::time::Duration::from_millis(state.delay_ms)).await;
+
+    let status_code = if state.embeddings_status_code == 0 {
+        StatusCode::OK
+    } else {
+        StatusCode::from_u16(state.embeddings_status_code)
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+    };
+    if !status_code.is_success() {
+        let message = state
+            .embeddings_error_body
+            .clone()
+            .unwrap_or_else(|| "mock embeddings failure".into());
+        return (
+            status_code,
+            Json(serde_json::json!({"error": {"message": message}})),
+        )
+            .into_response();
+    }
 
     let model = body
         .get("model")

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -44,6 +44,7 @@ async fn build_e2e_app_with_failure(
         api_key: None,
         free_only: true,
         discover_models: true,
+        embedding_support: Default::default(),
     }];
 
     let state = tokenscavenger::app::state::AppState::new(
@@ -190,6 +191,10 @@ async fn build_e2e_app_with_failure(
         .route(
             "/v1/chat/completions",
             post(tokenscavenger::api::routes::chat_completions),
+        )
+        .route(
+            "/v1/embeddings",
+            post(tokenscavenger::api::routes::embeddings),
         )
         .route("/v1/models", get(tokenscavenger::api::routes::models))
         .route("/healthz", get(tokenscavenger::api::routes::healthz))
@@ -496,6 +501,31 @@ async fn e2e_disabled_model_is_not_routed_for_streaming() {
                         "model": "test-model",
                         "stream": true,
                         "messages": [{"role":"user","content":"Hi"}]
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn e2e_model_without_embeddings_support_is_not_routed_for_embeddings() {
+    let (app, _state) = build_e2e_app(0).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/embeddings")
+                .method("POST")
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({
+                        "model": "test-model",
+                        "input": "hello"
                     }))
                     .unwrap(),
                 ))

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -178,6 +178,7 @@ async fn test_admin_config_redacts_provider_secrets() {
             api_key: Some("gsk_super_secret_key".into()),
             free_only: true,
             discover_models: true,
+            embedding_support: Default::default(),
         }],
         ..Default::default()
     };
@@ -393,6 +394,7 @@ async fn test_admin_config_save_preserves_redacted_provider_api_key() {
             api_key: Some("gsk_super_secret_key".into()),
             free_only: true,
             discover_models: true,
+            embedding_support: Default::default(),
         }],
         ..Default::default()
     };
@@ -820,14 +822,15 @@ async fn test_route_plan_endpoint_explains_attempts() {
         .await
         .unwrap();
     let mut config = Config::default();
-    config.routing.provider_order = vec!["groq".into()];
+    config.routing.provider_order = vec!["local".into()];
     config.providers = vec![tokenscavenger::config::schema::ProviderConfig {
-        id: "groq".into(),
+        id: "local".into(),
         enabled: true,
         base_url: None,
         api_key: None,
         free_only: true,
         discover_models: false,
+        embedding_support: Default::default(),
     }];
     let state = AppState::new(
         config,
@@ -836,12 +839,33 @@ async fn test_route_plan_endpoint_explains_attempts() {
         tokio::sync::broadcast::channel(1).0,
     );
     state.provider_registry.init_from_config(&state).await;
+    sqlx::query(
+        "INSERT INTO providers (provider_id, display_name, enabled, base_url, free_only)
+         VALUES (?, ?, 1, ?, 1)",
+    )
+    .bind("local")
+    .bind("Local")
+    .bind("http://127.0.0.1:1234/v1")
+    .execute(&state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO models (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, supports_embeddings, discovered_at, updated_at)
+         VALUES (?, ?, ?, 1, 1, 1, 0, datetime('now'), datetime('now'))",
+    )
+    .bind("local")
+    .bind("test-local")
+    .bind("test-local")
+    .execute(&state.db)
+    .await
+    .unwrap();
     let router = tokenscavenger::app::startup::build_router(state);
 
     let response = router
+        .clone()
         .oneshot(
             Request::builder()
-                .uri("/admin/route-plan?model=llama3-8b-8192&endpoint=chat")
+                .uri("/admin/route-plan?model=test-local&endpoint=chat")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -853,9 +877,35 @@ async fn test_route_plan_endpoint_explains_attempts() {
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["requested_model"], "llama3-8b-8192");
+    assert_eq!(json["requested_model"], "test-local");
+    assert!(
+        json["attempts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|attempt| { attempt["provider_id"] == "local" && attempt["included"] == true })
+    );
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/admin/route-plan?model=test-local&endpoint=embeddings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 65536)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(json["attempts"].as_array().unwrap().iter().any(|attempt| {
-        attempt["provider_id"] == "groq" && attempt["reason"].as_str().is_some()
+        attempt["provider_id"] == "local"
+            && attempt["included"] == false
+            && attempt["reason"]
+                .as_str()
+                .is_some_and(|reason| reason.contains("model endpoint capability"))
     }));
 }
 
@@ -1065,6 +1115,7 @@ async fn test_provider_contract_matrix_and_failure_classification() {
             api_key: None,
             free_only: true,
             discover_models: false,
+            embedding_support: Default::default(),
         })
         .collect();
     let state = AppState::new(
@@ -1110,7 +1161,7 @@ async fn test_provider_contract_matrix_and_failure_classification() {
 }
 
 #[tokio::test]
-async fn test_local_openai_adapter_supports_embeddings() {
+async fn test_local_openai_adapter_auto_probes_embeddings() {
     let (base_url, handle) = common::start_mock_server(common::MockProviderState {
         usage_tokens: (3, 0),
         ..Default::default()
@@ -1125,6 +1176,7 @@ async fn test_local_openai_adapter_supports_embeddings() {
         api_key: None,
         free_only: true,
         discover_models: true,
+        embedding_support: Default::default(),
     };
     let ctx = tokenscavenger::providers::traits::ProviderContext {
         base_url: tokenscavenger::providers::traits::ProviderAdapter::base_url(&adapter, &config),
@@ -1166,6 +1218,148 @@ async fn test_local_openai_adapter_supports_embeddings() {
     assert_eq!(response.model_id, "local-embed");
     assert_eq!(response.data[0].embedding, vec![0.125, -0.25, 0.5]);
     assert_eq!(response.usage.prompt_tokens, 3);
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_local_openai_adapter_does_not_advertise_embeddings_when_probe_fails() {
+    let (base_url, handle) = common::start_mock_server(common::MockProviderState {
+        embeddings_status_code: 501,
+        embeddings_error_body: Some("embeddings disabled".into()),
+        ..Default::default()
+    })
+    .await;
+
+    let adapter = tokenscavenger::providers::local::LocalOpenAiAdapter;
+    let config = tokenscavenger::config::schema::ProviderConfig {
+        id: "local".into(),
+        enabled: true,
+        base_url: Some(format!("{base_url}/v1")),
+        api_key: None,
+        free_only: true,
+        discover_models: true,
+        embedding_support: tokenscavenger::config::schema::ProviderEmbeddingSupport::Auto,
+    };
+    let ctx = tokenscavenger::providers::traits::ProviderContext {
+        base_url: tokenscavenger::providers::traits::ProviderAdapter::base_url(&adapter, &config),
+        api_key: None,
+        config: std::sync::Arc::new(config),
+        client: reqwest::Client::new(),
+    };
+
+    let models =
+        tokenscavenger::providers::traits::ProviderAdapter::discover_models(&adapter, &ctx)
+            .await
+            .unwrap();
+    assert!(
+        !models[0]
+            .endpoint_compatibility
+            .contains(&"embeddings".to_string())
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_local_openai_adapter_embedding_support_can_be_configured() {
+    let (base_url, handle) = common::start_mock_server(common::MockProviderState {
+        embeddings_status_code: 501,
+        embeddings_error_body: Some("embeddings disabled".into()),
+        ..Default::default()
+    })
+    .await;
+
+    let adapter = tokenscavenger::providers::local::LocalOpenAiAdapter;
+    let mut config = tokenscavenger::config::schema::ProviderConfig {
+        id: "local".into(),
+        enabled: true,
+        base_url: Some(format!("{base_url}/v1")),
+        api_key: None,
+        free_only: true,
+        discover_models: true,
+        embedding_support: tokenscavenger::config::schema::ProviderEmbeddingSupport::Enabled,
+    };
+    let mut ctx = tokenscavenger::providers::traits::ProviderContext {
+        base_url: tokenscavenger::providers::traits::ProviderAdapter::base_url(&adapter, &config),
+        api_key: None,
+        config: std::sync::Arc::new(config.clone()),
+        client: reqwest::Client::new(),
+    };
+
+    let forced_models =
+        tokenscavenger::providers::traits::ProviderAdapter::discover_models(&adapter, &ctx)
+            .await
+            .unwrap();
+    assert!(
+        forced_models[0]
+            .endpoint_compatibility
+            .contains(&"embeddings".to_string())
+    );
+
+    config.embedding_support = tokenscavenger::config::schema::ProviderEmbeddingSupport::Disabled;
+    ctx.config = std::sync::Arc::new(config);
+    let disabled_models =
+        tokenscavenger::providers::traits::ProviderAdapter::discover_models(&adapter, &ctx)
+            .await
+            .unwrap();
+    assert!(
+        !disabled_models[0]
+            .endpoint_compatibility
+            .contains(&"embeddings".to_string())
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn test_local_openai_adapter_auto_probes_embeddings_with_bounded_concurrency() {
+    let (base_url, handle) = common::start_mock_server(common::MockProviderState {
+        delay_ms: 250,
+        model_ids: vec![
+            "local-a".into(),
+            "local-b".into(),
+            "local-c".into(),
+            "local-d".into(),
+        ],
+        ..Default::default()
+    })
+    .await;
+
+    let adapter = tokenscavenger::providers::local::LocalOpenAiAdapter;
+    let config = tokenscavenger::config::schema::ProviderConfig {
+        id: "local".into(),
+        enabled: true,
+        base_url: Some(format!("{base_url}/v1")),
+        api_key: None,
+        free_only: true,
+        discover_models: true,
+        embedding_support: tokenscavenger::config::schema::ProviderEmbeddingSupport::Auto,
+    };
+    let ctx = tokenscavenger::providers::traits::ProviderContext {
+        base_url: tokenscavenger::providers::traits::ProviderAdapter::base_url(&adapter, &config),
+        api_key: None,
+        config: std::sync::Arc::new(config),
+        client: reqwest::Client::new(),
+    };
+
+    let started_at = std::time::Instant::now();
+    let models =
+        tokenscavenger::providers::traits::ProviderAdapter::discover_models(&adapter, &ctx)
+            .await
+            .unwrap();
+    let elapsed = started_at.elapsed();
+
+    assert_eq!(models.len(), 4);
+    assert!(models.iter().all(|model| {
+        model
+            .endpoint_compatibility
+            .contains(&"embeddings".to_string())
+    }));
+    assert!(
+        elapsed < std::time::Duration::from_millis(800),
+        "local embeddings probes should be bounded-concurrent, elapsed={elapsed:?}"
+    );
 
     handle.abort();
 }
@@ -1363,6 +1557,7 @@ async fn test_disabled_provider_is_not_registered() {
             api_key: None,
             free_only: true,
             discover_models: true,
+            embedding_support: Default::default(),
         }],
         ..Default::default()
     };


### PR DESCRIPTION
## Summary

- Enforce persisted per-model endpoint capabilities during chat, streaming, and embeddings route filtering.
- Make local OpenAI-compatible embedding discovery probed/configurable via `embedding_support = "auto" | "enabled" | "disabled"`.
- Bound local auto embedding probes to 4 concurrent requests with a short per-model timeout.
- Preserve upstream non-2xx embeddings error bodies before JSON parsing.
- Fix Prometheus build metadata to report the running package version.
- Update route-plan explanations, docs, changelog, and tests.
- Replace the crude README ASCII architecture diagram with a logo-theme SVG architecture diagram.

## Why

The v0.3.0 local provider support could over-advertise embeddings for local chat-only models, and route planning did not enforce persisted model endpoint capability flags. That made local embeddings unsafe in real Ollama setups and made observability misleading.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `git diff --check`
- `xmllint --noout resources/ArchitectureDiagram.svg`
- QuickLook-rendered `resources/ArchitectureDiagram.svg` locally for visual inspection

## CI

CI completed successfully for the code-fix commit (`d4b2cde`). After the README/SVG-only diagram commit (`86ae987`), GitHub reported no checks on the branch; the full local validation above was rerun after that commit.

## Notes

- `.dev/` and local artifacts are not included.
- This should release as a patch fix, `v0.3.1`, through the existing GitHub Actions release workflow.