### PR TITLE
Implement Model Intelligence Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a Model Intelligence Layer with normalized model families, task tags,
+  modalities, context-window metadata, reasoning/vision/tool/JSON capability
+  signals, and catalog freshness scoring.
+- Added built-in smart model groups for `fast:chat`, `cheap:code`,
+  `reasoning:deep`, and `vision:balanced`.
+
 ### Changed
 
+- `/v1/models`, `/admin/models`, the Models UI, and route-plan diagnostics now
+  expose model intelligence metadata for easier provider/model comparison.
+
 ### Fixed
+
+- Chat and streaming route planning now reroutes before upstream calls when a
+  model cannot satisfy requested tools, JSON mode, vision input, or known
+  context-window requirements.
 
 ## [0.3.1] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 - **Free-tier-first routing** with configurable fallback chains
 - **Tool-aware routing** for agentic clients, preferring stronger tool-call
   providers automatically when OpenAI `tools` are present
+- **Model intelligence layer** with smart groups, task tags, modality flags,
+  context-window awareness, and catalog freshness scoring
 - **Full OpenAI-compatible API** (chat completions + streaming SSE, embeddings, `/v1/models`)
 - **18 built-in providers** with automatic model discovery, including local OpenAI-compatible upstreams
 - **Circuit breakers, retries & health monitoring**
@@ -271,6 +273,20 @@ budgets can cap estimated spend per request, per day, per provider/day, or per
 model-group/day. Route-plan diagnostics show score components, estimated cost,
 latency, failure rate, and budget skip reasons.
 
+## Model Intelligence
+
+TokenScavenger normalizes model families, task tags, modality flags, context
+windows, JSON/tool support, reasoning hints, embeddings support, and catalog
+freshness into the merged model catalog. Built-in smart model groups such as
+`fast:chat`, `cheap:code`, `reasoning:deep`, and `vision:balanced` sit on top
+of the normal model-group system, so operators can edit or override them in the
+UI.
+
+Chat and streaming route planning uses this metadata to reroute before calling
+an upstream when a model cannot satisfy requested tools, JSON mode, vision input,
+or known context-window requirements. `/admin/route-plan` exposes the same
+compatibility decisions for dry-run diagnostics.
+
 ## Provider Support Matrix
 
 See [documentation/provider-matrix.md](documentation/provider-matrix.md) for details on each provider's API format, free tier limits, and known quirks.
@@ -289,8 +305,8 @@ Open `http://localhost:8000/ui` in your browser for the operator dashboard with 
 
 - Dashboard — system status, uptime, provider count
 - Providers — enable/disable, inspect health and breaker state
-- Models — view discovered and curated models
-- Routing — view fallback order and model group configuration
+- Models — compare discovered and curated models with intelligence metadata
+- Routing — view fallback order and smart/custom model group configuration
 - Usage — token counts and estimated costs
 - Health — per-provider health states
 - Logs — real-time log stream via SSE

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,17 +36,19 @@ This roadmap is intentionally focused on five high-value enhancements. Each one 
 
 ## 3. Model Intelligence Layer
 
+**Status:** Implemented in v0.3.2.
+
 **Current baseline:** TokenScavenger already merges curated and discovered model catalogs, supports model groups, exposes model enablement and priority controls, and documents provider capabilities. Model group editing exists in the admin UI.
 
 **Why it matters:** Operators should not have to memorize every upstream model name or manually guess equivalent fallbacks. TokenScavenger can become the map between task intent and concrete provider models.
 
 **What good looks like:**
 
-- Normalized model families, task tags, context windows, modality flags, JSON/tool support, reasoning support, and pricing metadata.
-- Higher-level smart model groups such as `fast:chat`, `cheap:code`, `reasoning:deep`, and `vision:balanced` built on top of the existing model group system.
-- Compatibility checks that reject or reroute when a provider cannot satisfy tools, JSON mode, vision, embeddings, or context length.
-- Automatic catalog freshness scoring so stale discovery data is visible.
-- Admin UI flows for comparing models across providers and editing advanced model group strategies without hand-writing JSON.
+- [x] Normalized model families, task tags, context windows, modality flags, JSON/tool support, reasoning support, and pricing metadata.
+- [x] Higher-level smart model groups such as `fast:chat`, `cheap:code`, `reasoning:deep`, and `vision:balanced` built on top of the existing model group system.
+- [x] Compatibility checks that reject or reroute when a provider cannot satisfy tools, JSON mode, vision, embeddings, or context length.
+- [x] Automatic catalog freshness scoring so stale discovery data is visible.
+- [x] Admin UI flows for comparing models across providers and editing advanced model group strategies without hand-writing JSON.
 
 ## 4. Operator-Grade Observability And Incident Workflow
 

--- a/documentation/api-behavior.md
+++ b/documentation/api-behavior.md
@@ -8,7 +8,7 @@ TokenScavenger exposes OpenAI-compatible HTTP endpoints while routing each reque
 |----------|-------------|
 | `POST /v1/chat/completions` | OpenAI-compatible chat completions, including streaming SSE when `stream: true`. |
 | `POST /v1/embeddings` | OpenAI-compatible embeddings for providers that support embeddings. |
-| `GET /v1/models` | Merged public model catalog from curated models, discovery, and operator configuration. |
+| `GET /v1/models` | Merged public model catalog from curated models, discovery, operator configuration, and model intelligence metadata. |
 | `GET /healthz` | Lightweight process health check. |
 | `GET /readyz` | Readiness check with dependency state. |
 | `GET /metrics` | Prometheus metrics. |
@@ -80,6 +80,20 @@ Useful metrics include:
 - `tokenscavenger_provider_health_state`
 - `tokenscavenger_provider_breaker_state`
 - `tokenscavenger_quota_remaining`
+
+## Model Intelligence
+
+`GET /v1/models` remains OpenAI-compatible but may include additional optional
+fields such as `provider_id`, `free_tier`, `context_window`, `task_tags`,
+`modalities`, and `freshness`. Clients that only expect OpenAI's base model
+shape can ignore these fields.
+
+Chat and streaming route planning also consults model intelligence metadata.
+Candidates are skipped before upstream calls when the request needs tools, JSON
+mode, vision input, or a known context window that the model cannot satisfy.
+`/admin/route-plan` exposes the same compatibility decision with query hints
+such as `tools=true`, `json=true`, `vision=true`, `input_tokens=...`, and
+`output_tokens=...`.
 
 ## Streaming Errors
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -145,6 +145,13 @@ Hermes-style coding harnesses prefer providers with stronger tool-call behavior
 while still respecting enabled models, provider health, circuit breakers,
 budgets, and paid-fallback policy.
 
+Model intelligence metadata is also applied before policy scoring. TokenScavenger
+normalizes model family, task tags, modalities, context window, tool/JSON/vision
+signals, reasoning hints, embeddings support, and discovery freshness from the
+curated and discovered catalog. Requests that need tools, JSON mode, vision
+input, or a context length larger than a model's known window are rerouted before
+an upstream call is made.
+
 ### `[resilience]`
 
 | Field | Default | Description |
@@ -198,6 +205,16 @@ serially stall the refresh cycle.
 |-------|---------|-------------|
 | `name` | *(required)* | Public model group name used in the `model` field of requests |
 | `target` | *(required)* | Single target or ordered target array. Strings are model IDs that can route through any eligible provider. Objects pin a model to one provider: `{ provider = "nvidia", model = "google/gemma-4-31b-it" }`. |
+
+TokenScavenger seeds editable smart groups on first run:
+
+- `fast:chat`
+- `cheap:code`
+- `reasoning:deep`
+- `vision:balanced`
+
+They use the same `model_groups` table and are inserted only when absent, so
+operator-edited groups are never overwritten by startup seeding.
 
 ## Example Configurations
 

--- a/src/api/openai/models.rs
+++ b/src/api/openai/models.rs
@@ -19,4 +19,12 @@ pub struct ModelEntry {
     pub provider_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub free_tier: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modalities: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freshness: Option<String>,
 }

--- a/src/api/openai/stream.rs
+++ b/src/api/openai/stream.rs
@@ -3,6 +3,9 @@ use crate::api::openai::chat::NormalizedChatRequest;
 use crate::api::openai::chat::StreamDelta;
 use crate::api::openai::chat::UsageResponse;
 use crate::app::state::AppState;
+use crate::discovery::model_intelligence::{
+    ModelRequestRequirements, filter_by_model_intelligence,
+};
 use crate::providers::traits::{EndpointKind, ProviderContext, ProviderError};
 use crate::router::policy::RoutePolicy;
 use crate::router::selection::{
@@ -224,6 +227,8 @@ pub async fn create_chat_stream(
         EndpointKind::ChatCompletions,
     )
     .await;
+    plan = filter_by_model_intelligence(plan, &state, ModelRequestRequirements::for_chat(&request))
+        .await;
     if request.tools.is_some() {
         plan = prioritize_for_tool_use(plan, &state).await;
     }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -312,6 +312,24 @@ pub async fn admin_route_plan(
             .and_then(|value| value.parse::<u32>().ok())
             .unwrap_or(1024),
     };
+    let route_requirements = crate::discovery::model_intelligence::ModelRequestRequirements {
+        requires_tools: params
+            .get("tools")
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(false),
+        requires_json_mode: params
+            .get("json")
+            .or_else(|| params.get("json_mode"))
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(false),
+        requires_vision: params
+            .get("vision")
+            .and_then(|value| value.parse::<bool>().ok())
+            .unwrap_or(false),
+        required_context_tokens: Some(
+            u64::from(token_estimate.input_tokens) + u64::from(token_estimate.output_tokens),
+        ),
+    };
     let explanations = crate::router::selection::explain_policy_plan(
         raw_plan,
         &state,
@@ -349,6 +367,12 @@ pub async fn admin_route_plan(
             crate::providers::traits::EndpointKind::Embeddings => model_state.2,
             crate::providers::traits::EndpointKind::ModelList => true,
         };
+        let compatibility = crate::discovery::model_intelligence::model_compatibility(
+            &state,
+            &attempt,
+            route_requirements,
+        )
+        .await;
         let free_only = config
             .providers
             .iter()
@@ -358,6 +382,7 @@ pub async fn admin_route_plan(
         let paid_allowed = free_only || config.routing.allow_paid_fallback;
         let base_included = model_enabled
             && endpoint_supported
+            && compatibility.compatible
             && paid_allowed
             && health != "Unhealthy"
             && breaker != "Open"
@@ -369,11 +394,17 @@ pub async fn admin_route_plan(
             Some("filtered by paid fallback policy")
         } else if !endpoint_supported {
             Some("filtered by model endpoint capability")
+        } else if !compatibility.compatible {
+            Some("filtered by model intelligence compatibility")
         } else {
             Some("filtered by health, breaker, or model enablement")
         };
         let mut reasons = explanation.reasons;
+        reasons.extend(compatibility.reasons);
         if let Some(base_reason) = base_reason {
+            if base_reason == "filtered by model intelligence compatibility" {
+                reasons.retain(|reason| reason != "eligible");
+            }
             reasons.insert(0, base_reason.to_string());
         }
         let reason = reasons.join("; ");
@@ -398,6 +429,7 @@ pub async fn admin_route_plan(
             "health": health,
             "breaker_state": breaker,
             "model_enabled": model_enabled,
+            "model_intelligence_compatible": compatibility.compatible,
             "free_only": free_only,
             "included": included,
             "reason": reason,
@@ -415,6 +447,12 @@ pub async fn admin_route_plan(
         "token_estimate": {
             "input_tokens": token_estimate.input_tokens,
             "output_tokens": token_estimate.output_tokens
+        },
+        "requirements": {
+            "tools": route_requirements.requires_tools,
+            "json_mode": route_requirements.requires_json_mode,
+            "vision": route_requirements.requires_vision,
+            "context_tokens": route_requirements.required_context_tokens
         },
         "attempts": attempts
     })))
@@ -730,8 +768,26 @@ pub async fn admin_config_save(
             ) {
                 let enabled = model_update.get("enabled").and_then(|v| v.as_bool());
                 let priority = model_update.get("priority").and_then(|v| v.as_i64());
+                let supports_tools = model_update.get("supports_tools").and_then(|v| v.as_bool());
+                let supports_json_mode = model_update
+                    .get("supports_json_mode")
+                    .and_then(|v| v.as_bool());
+                let supports_vision = model_update
+                    .get("supports_vision")
+                    .and_then(|v| v.as_bool());
+                let metadata_json = model_update.get("metadata").or_else(|| {
+                    model_update
+                        .get("metadata_json")
+                        .filter(|value| value.is_object())
+                });
 
-                if enabled.is_some() || priority.is_some() {
+                if enabled.is_some()
+                    || priority.is_some()
+                    || supports_tools.is_some()
+                    || supports_json_mode.is_some()
+                    || supports_vision.is_some()
+                    || metadata_json.is_some()
+                {
                     let mut query = String::from(
                         "INSERT INTO models (provider_id, upstream_model_id, public_model_id, updated_at",
                     );
@@ -750,6 +806,26 @@ pub async fn admin_config_save(
                         values.push_str(", ?");
                         update.push_str(", priority = excluded.priority");
                     }
+                    if supports_tools.is_some() {
+                        query.push_str(", supports_tools");
+                        values.push_str(", ?");
+                        update.push_str(", supports_tools = excluded.supports_tools");
+                    }
+                    if supports_json_mode.is_some() {
+                        query.push_str(", supports_json_mode");
+                        values.push_str(", ?");
+                        update.push_str(", supports_json_mode = excluded.supports_json_mode");
+                    }
+                    if supports_vision.is_some() {
+                        query.push_str(", supports_vision");
+                        values.push_str(", ?");
+                        update.push_str(", supports_vision = excluded.supports_vision");
+                    }
+                    if metadata_json.is_some() {
+                        query.push_str(", metadata_json");
+                        values.push_str(", ?");
+                        update.push_str(", metadata_json = excluded.metadata_json");
+                    }
 
                     let full_query = format!("{} {}) {}", query, values, update);
                     let mut sql = sqlx::query(&full_query)
@@ -762,6 +838,18 @@ pub async fn admin_config_save(
                     }
                     if let Some(p) = priority {
                         sql = sql.bind(p);
+                    }
+                    if let Some(supports_tools) = supports_tools {
+                        sql = sql.bind(supports_tools);
+                    }
+                    if let Some(supports_json_mode) = supports_json_mode {
+                        sql = sql.bind(supports_json_mode);
+                    }
+                    if let Some(supports_vision) = supports_vision {
+                        sql = sql.bind(supports_vision);
+                    }
+                    if let Some(metadata_json) = metadata_json {
+                        sql = sql.bind(metadata_json.to_string());
                     }
 
                     if let Err(e) = sql.execute(&state.db).await {

--- a/src/app/startup.rs
+++ b/src/app/startup.rs
@@ -82,6 +82,11 @@ pub async fn startup(config_path: &Path) -> Result<StartupResult, Box<dyn std::e
     crate::discovery::curated::seed_curated_models(&state.db).await;
     info!("Curated models seeded");
 
+    // 5d. Seed built-in smart model groups. Operator-edited groups win because
+    //     this uses INSERT OR IGNORE rather than overwriting existing rows.
+    crate::discovery::model_intelligence::seed_smart_model_groups(&state.db).await;
+    info!("Smart model groups seeded");
+
     // 6. Initialize the provider registry from effective config
     state.provider_registry.init_from_config(&state).await;
     info!("Provider registry initialized");

--- a/src/discovery/curated.rs
+++ b/src/discovery/curated.rs
@@ -215,11 +215,21 @@ pub async fn seed_curated_models(db: &sqlx::SqlitePool) {
             .endpoint_compatibility
             .iter()
             .any(|kind| kind == "embeddings");
+        let intelligence_metadata = crate::discovery::model_intelligence::intelligence_metadata(
+            &model.provider_id,
+            &model.upstream_model_id,
+            model.context_window,
+            supports_embeddings,
+        );
+        let supports_vision = intelligence_metadata
+            .get("supports_vision")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
         let _ = sqlx::query(
             "INSERT OR IGNORE INTO models \
              (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, supports_embeddings, \
-              metadata_json, discovered_at, updated_at) \
-             VALUES (?, ?, ?, 1, ?, ?, ?, ?, datetime('now'), datetime('now'))",
+              supports_vision, metadata_json, discovered_at, updated_at) \
+             VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
         )
         .bind(&model.provider_id)
         .bind(&model.upstream_model_id)
@@ -232,7 +242,8 @@ pub async fn seed_curated_models(db: &sqlx::SqlitePool) {
         .bind(model.free_tier)
         .bind(supports_chat)
         .bind(supports_embeddings)
-        .bind(serde_json::json!({"context_window": model.context_window}).to_string())
+        .bind(supports_vision)
+        .bind(intelligence_metadata.to_string())
         .execute(db)
         .await;
     }

--- a/src/discovery/merge.rs
+++ b/src/discovery/merge.rs
@@ -14,18 +14,24 @@ pub async fn build_model_list(state: &AppState) -> ModelListResponse {
 
     // Insert curated entries first
     for m in &curated {
+        let metadata = crate::discovery::model_intelligence::intelligence_metadata(
+            &m.provider_id,
+            &m.upstream_model_id,
+            m.context_window,
+            false,
+        )
+        .to_string();
         models_map.insert(
             (m.provider_id.clone(), m.upstream_model_id.clone()),
-            ModelEntry {
-                id: m.upstream_model_id.clone(),
-                object: "model".into(),
-                created: 0,
-                owned_by: m.provider_id.clone(),
-                permission: vec![],
-                root: None,
-                provider_id: Some(m.provider_id.clone()),
-                free_tier: Some(m.free_tier),
-            },
+            model_entry(
+                &m.provider_id,
+                &m.upstream_model_id,
+                Some(m.free_tier),
+                Some(&metadata),
+                None,
+                None,
+                None,
+            ),
         );
     }
 
@@ -39,18 +45,19 @@ pub async fn build_model_list(state: &AppState) -> ModelListResponse {
             .get("provider_id")
             .and_then(|v| v.as_str())
             .unwrap_or("unknown");
+        let metadata_json = m.get("metadata_json").and_then(|v| v.as_str());
+        let free_tier = m.get("free_tier").and_then(|v| v.as_bool()).or(Some(true));
         models_map.insert(
             (provider.to_string(), id.to_string()),
-            ModelEntry {
-                id: id.to_string(),
-                object: "model".into(),
-                created: 0,
-                owned_by: provider.to_string(),
-                permission: vec![],
-                root: None,
-                provider_id: Some(provider.to_string()),
-                free_tier: Some(true),
-            },
+            model_entry(
+                provider,
+                id,
+                free_tier,
+                metadata_json,
+                m.get("supports_embeddings").and_then(|v| v.as_bool()),
+                m.get("discovery_state").and_then(|v| v.as_str()),
+                m.get("updated_at").and_then(|v| v.as_str()),
+            ),
         );
     }
 
@@ -59,6 +66,42 @@ pub async fn build_model_list(state: &AppState) -> ModelListResponse {
     ModelListResponse {
         object: "list".into(),
         data,
+    }
+}
+
+fn model_entry(
+    provider: &str,
+    id: &str,
+    free_tier: Option<bool>,
+    metadata_json: Option<&str>,
+    supports_embeddings: Option<bool>,
+    discovery_state: Option<&str>,
+    updated_at: Option<&str>,
+) -> ModelEntry {
+    let intelligence = crate::discovery::model_intelligence::infer_model_intelligence(
+        provider,
+        id,
+        metadata_json,
+        supports_embeddings.unwrap_or(false),
+        discovery_state,
+        None,
+        updated_at,
+    );
+    ModelEntry {
+        id: id.to_string(),
+        object: "model".into(),
+        created: 0,
+        owned_by: provider.to_string(),
+        permission: vec![],
+        root: None,
+        provider_id: Some(provider.to_string()),
+        free_tier,
+        context_window: intelligence.context_window,
+        task_tags: Some(intelligence.task_tags),
+        modalities: Some(intelligence.modalities),
+        freshness: Some(crate::discovery::model_intelligence::freshness_label(
+            &intelligence.freshness,
+        )),
     }
 }
 
@@ -78,21 +121,84 @@ pub async fn get_all_models(state: &AppState) -> serde_json::Value {
                 "free_tier": model.free_tier,
                 "priority": 100,
                 "source": "curated",
+                "intelligence": crate::discovery::model_intelligence::infer_model_intelligence(
+                    &model.provider_id,
+                    &model.upstream_model_id,
+                    Some(&crate::discovery::model_intelligence::intelligence_metadata(
+                        &model.provider_id,
+                        &model.upstream_model_id,
+                        model.context_window,
+                        false,
+                    ).to_string()),
+                    false,
+                    None,
+                    None,
+                    None,
+                ),
             }),
         );
     }
 
-    let result = sqlx::query_as::<_, (String, String, String, bool, bool, i64)>(
-        "SELECT provider_id, upstream_model_id, public_model_id, enabled, free_tier, priority FROM models ORDER BY provider_id, upstream_model_id",
+    let result = sqlx::query_as::<
+        _,
+        (
+            String,
+            String,
+            String,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ),
+    >(
+        "SELECT m.provider_id, m.upstream_model_id, m.public_model_id, m.enabled, m.free_tier,
+                m.supports_chat, m.supports_embeddings, m.supports_tools, m.supports_json_mode,
+                m.supports_vision, m.priority, m.metadata_json, p.discovery_state,
+                m.discovered_at, m.updated_at
+         FROM models m
+         LEFT JOIN providers p ON p.provider_id = m.provider_id
+         ORDER BY m.provider_id, m.upstream_model_id",
     )
     .fetch_all(&state.db)
     .await;
 
     match result {
         Ok(rows) => {
-            for (provider_id, upstream_model_id, public_model_id, enabled, free_tier, priority) in
-                rows
+            for (
+                provider_id,
+                upstream_model_id,
+                public_model_id,
+                enabled,
+                free_tier,
+                supports_chat,
+                supports_embeddings,
+                supports_tools,
+                supports_json_mode,
+                supports_vision,
+                priority,
+                metadata_json,
+                discovery_state,
+                discovered_at,
+                updated_at,
+            ) in rows
             {
+                let intelligence = crate::discovery::model_intelligence::infer_model_intelligence(
+                    &provider_id,
+                    &upstream_model_id,
+                    metadata_json.as_deref(),
+                    supports_embeddings,
+                    discovery_state.as_deref(),
+                    discovered_at.as_deref(),
+                    updated_at.as_deref(),
+                );
                 models_map.insert(
                     (provider_id.clone(), upstream_model_id.clone()),
                     serde_json::json!({
@@ -101,7 +207,16 @@ pub async fn get_all_models(state: &AppState) -> serde_json::Value {
                         "public_model_id": public_model_id,
                         "enabled": enabled,
                         "free_tier": free_tier,
+                        "supports_chat": supports_chat,
+                        "supports_embeddings": supports_embeddings,
+                        "supports_tools": supports_tools,
+                        "supports_json_mode": supports_json_mode,
+                        "supports_vision": supports_vision || intelligence.supports_vision,
                         "priority": priority,
+                        "discovery_state": discovery_state,
+                        "freshness": crate::discovery::model_intelligence::freshness_label(&intelligence.freshness),
+                        "freshness_score": intelligence.freshness_score,
+                        "intelligence": intelligence,
                         "source": "database",
                     }),
                 );
@@ -116,8 +231,25 @@ pub async fn get_all_models(state: &AppState) -> serde_json::Value {
 }
 
 async fn get_discovered_from_db(state: &AppState) -> Vec<serde_json::Value> {
-    let result = sqlx::query_as::<_, (String, String, String, bool)>(
-        "SELECT provider_id, upstream_model_id, public_model_id, enabled FROM models WHERE enabled = 1"
+    let result = sqlx::query_as::<
+        _,
+        (
+            String,
+            String,
+            String,
+            bool,
+            bool,
+            bool,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ),
+    >(
+        "SELECT m.provider_id, m.upstream_model_id, m.public_model_id, m.enabled, m.free_tier,
+                m.supports_embeddings, m.metadata_json, m.updated_at, p.discovery_state
+         FROM models m
+         LEFT JOIN providers p ON p.provider_id = m.provider_id
+         WHERE m.enabled = 1",
     )
     .fetch_all(&state.db)
     .await;
@@ -125,13 +257,30 @@ async fn get_discovered_from_db(state: &AppState) -> Vec<serde_json::Value> {
     match result {
         Ok(rows) => rows
             .into_iter()
-            .map(|(p, u, pub_id, _e)| {
-                serde_json::json!({
-                    "provider_id": p,
-                    "upstream_model_id": u,
-                    "public_model_id": pub_id,
-                })
-            })
+            .map(
+                |(
+                    p,
+                    u,
+                    pub_id,
+                    _e,
+                    free_tier,
+                    supports_embeddings,
+                    metadata_json,
+                    updated_at,
+                    discovery_state,
+                )| {
+                    serde_json::json!({
+                        "provider_id": p,
+                        "upstream_model_id": u,
+                        "public_model_id": pub_id,
+                        "free_tier": free_tier,
+                        "supports_embeddings": supports_embeddings,
+                        "metadata_json": metadata_json,
+                        "updated_at": updated_at,
+                        "discovery_state": discovery_state,
+                    })
+                },
+            )
             .collect(),
         Err(_) => vec![],
     }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -1,3 +1,4 @@
 pub mod curated;
 pub mod merge;
+pub mod model_intelligence;
 pub mod refresh;

--- a/src/discovery/model_intelligence.rs
+++ b/src/discovery/model_intelligence.rs
@@ -1,0 +1,544 @@
+use crate::api::openai::chat::NormalizedChatRequest;
+use crate::app::state::AppState;
+use crate::providers::traits::EndpointKind;
+use crate::router::selection::RouteAttempt;
+use serde::{Deserialize, Serialize};
+
+const STALE_AFTER_HOURS: i64 = 24 * 7;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CatalogFreshness {
+    Fresh,
+    Stale,
+    ErrorLastAttempt,
+    NeverDiscovered,
+    Disabled,
+    Curated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelIntelligence {
+    pub family: String,
+    pub task_tags: Vec<String>,
+    pub modalities: Vec<String>,
+    pub context_window: Option<u64>,
+    pub supports_tools: bool,
+    pub supports_json_mode: bool,
+    pub supports_reasoning: bool,
+    pub supports_vision: bool,
+    pub supports_embeddings: bool,
+    pub freshness: CatalogFreshness,
+    pub freshness_score: f64,
+}
+
+pub fn freshness_label(freshness: &CatalogFreshness) -> String {
+    serde_json::to_value(freshness)
+        .ok()
+        .and_then(|value| value.as_str().map(ToOwned::to_owned))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ModelRequestRequirements {
+    pub requires_tools: bool,
+    pub requires_json_mode: bool,
+    pub requires_vision: bool,
+    pub required_context_tokens: Option<u64>,
+}
+
+impl ModelRequestRequirements {
+    pub fn for_chat(request: &NormalizedChatRequest) -> Self {
+        let prompt_tokens = request
+            .prompt_size_hint()
+            .div_ceil(4)
+            .min(u64::MAX as usize) as u64;
+        Self {
+            requires_tools: request
+                .tools
+                .as_ref()
+                .is_some_and(|tools| !tools.is_empty()),
+            requires_json_mode: request.response_format.is_some(),
+            requires_vision: request_contains_image_input(request),
+            required_context_tokens: Some(
+                prompt_tokens + u64::from(request.max_tokens.unwrap_or(1024)),
+            ),
+        }
+    }
+
+    pub fn endpoint_only(_endpoint_kind: EndpointKind) -> Self {
+        Self {
+            requires_tools: false,
+            requires_json_mode: false,
+            requires_vision: false,
+            required_context_tokens: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CompatibilityDecision {
+    pub compatible: bool,
+    pub reasons: Vec<String>,
+}
+
+pub fn infer_model_intelligence(
+    provider_id: &str,
+    model_id: &str,
+    metadata_json: Option<&str>,
+    supports_embeddings: bool,
+    provider_discovery_state: Option<&str>,
+    discovered_at: Option<&str>,
+    updated_at: Option<&str>,
+) -> ModelIntelligence {
+    let metadata = metadata_json
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    let lower = model_id.to_ascii_lowercase();
+    let provider_lower = provider_id.to_ascii_lowercase();
+
+    let context_window = metadata
+        .get("context_window")
+        .and_then(|value| value.as_u64())
+        .or_else(|| infer_context_window(&lower));
+    let supports_vision = metadata
+        .get("supports_vision")
+        .and_then(|value| value.as_bool())
+        .unwrap_or_else(|| infer_vision(&provider_lower, &lower));
+    let supports_reasoning = metadata
+        .get("supports_reasoning")
+        .and_then(|value| value.as_bool())
+        .unwrap_or_else(|| infer_reasoning(&lower));
+    let family = metadata
+        .get("family")
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| infer_family(&provider_lower, &lower));
+    let task_tags = metadata
+        .get("task_tags")
+        .and_then(|value| value.as_array())
+        .map(|tags| {
+            tags.iter()
+                .filter_map(|tag| tag.as_str().map(ToOwned::to_owned))
+                .collect::<Vec<_>>()
+        })
+        .filter(|tags| !tags.is_empty())
+        .unwrap_or_else(|| infer_task_tags(&lower, supports_reasoning, supports_embeddings));
+    let mut modalities = vec!["text".to_string()];
+    if supports_vision {
+        modalities.push("vision".to_string());
+    }
+    if supports_embeddings {
+        modalities.push("embeddings".to_string());
+    }
+
+    let metadata_source = metadata.get("source").and_then(|value| value.as_str());
+    let freshness = freshness(
+        metadata_source,
+        provider_discovery_state,
+        discovered_at,
+        updated_at,
+    );
+    let freshness_score = freshness_score(&freshness);
+
+    ModelIntelligence {
+        family,
+        task_tags,
+        modalities,
+        context_window,
+        supports_tools: metadata
+            .get("supports_tools")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true),
+        supports_json_mode: metadata
+            .get("supports_json_mode")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(true),
+        supports_reasoning,
+        supports_vision,
+        supports_embeddings,
+        freshness,
+        freshness_score,
+    }
+}
+
+pub async fn model_compatibility(
+    state: &AppState,
+    attempt: &RouteAttempt,
+    requirements: ModelRequestRequirements,
+) -> CompatibilityDecision {
+    let row = sqlx::query_as::<
+        _,
+        (
+            bool,
+            bool,
+            bool,
+            bool,
+            bool,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ),
+    >(
+        "SELECT m.supports_chat, m.supports_embeddings, m.supports_tools, m.supports_json_mode,
+                m.supports_vision, m.metadata_json, p.discovery_state, m.discovered_at, m.updated_at
+         FROM models m
+         LEFT JOIN providers p ON p.provider_id = m.provider_id
+         WHERE m.provider_id = ? AND m.upstream_model_id = ?",
+    )
+    .bind(&attempt.provider_id)
+    .bind(&attempt.model_id)
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten();
+
+    let Some((
+        supports_chat,
+        supports_embeddings,
+        supports_tools,
+        supports_json_mode,
+        supports_vision,
+        metadata_json,
+        provider_discovery_state,
+        discovered_at,
+        updated_at,
+    )) = row
+    else {
+        return CompatibilityDecision {
+            compatible: true,
+            reasons: vec!["model intelligence unavailable; using provider capability".to_string()],
+        };
+    };
+
+    let intelligence = infer_model_intelligence(
+        &attempt.provider_id,
+        &attempt.model_id,
+        metadata_json.as_deref(),
+        supports_embeddings,
+        provider_discovery_state.as_deref(),
+        discovered_at.as_deref(),
+        updated_at.as_deref(),
+    );
+
+    let mut reasons = Vec::new();
+    if !supports_chat {
+        reasons.push("filtered by model chat capability".to_string());
+    }
+    if requirements.requires_tools && !(supports_tools && intelligence.supports_tools) {
+        reasons.push("filtered by model tool-call capability".to_string());
+    }
+    if requirements.requires_json_mode && !(supports_json_mode && intelligence.supports_json_mode) {
+        reasons.push("filtered by model JSON-mode capability".to_string());
+    }
+    if requirements.requires_vision && !(supports_vision || intelligence.supports_vision) {
+        reasons.push("filtered by model vision capability".to_string());
+    }
+    if let (Some(required), Some(context_window)) = (
+        requirements.required_context_tokens,
+        intelligence.context_window,
+    ) {
+        if required > context_window {
+            reasons.push(format!(
+                "filtered by context window: required {required} > available {context_window}"
+            ));
+        }
+    }
+
+    CompatibilityDecision {
+        compatible: reasons.is_empty(),
+        reasons,
+    }
+}
+
+pub async fn filter_by_model_intelligence(
+    plan: Vec<RouteAttempt>,
+    state: &AppState,
+    requirements: ModelRequestRequirements,
+) -> Vec<RouteAttempt> {
+    let mut filtered = Vec::with_capacity(plan.len());
+    for attempt in plan {
+        let decision = model_compatibility(state, &attempt, requirements).await;
+        if decision.compatible {
+            filtered.push(attempt);
+        } else {
+            tracing::info!(
+                provider = %attempt.provider_id,
+                model = %attempt.model_id,
+                reasons = ?decision.reasons,
+                "Filtered by model intelligence"
+            );
+        }
+    }
+    filtered
+}
+
+pub fn intelligence_metadata(
+    provider_id: &str,
+    model_id: &str,
+    context_window: Option<u64>,
+    supports_embeddings: bool,
+) -> serde_json::Value {
+    let inferred = infer_model_intelligence(
+        provider_id,
+        model_id,
+        Some(&serde_json::json!({"context_window": context_window}).to_string()),
+        supports_embeddings,
+        None,
+        None,
+        None,
+    );
+    serde_json::json!({
+        "context_window": context_window,
+        "family": inferred.family,
+        "task_tags": inferred.task_tags,
+        "modalities": inferred.modalities,
+        "supports_reasoning": inferred.supports_reasoning,
+        "supports_vision": inferred.supports_vision,
+        "supports_tools": inferred.supports_tools,
+        "supports_json_mode": inferred.supports_json_mode,
+        "source": "curated"
+    })
+}
+
+pub async fn seed_smart_model_groups(db: &sqlx::SqlitePool) {
+    for group in smart_model_groups() {
+        let _ = sqlx::query(
+            "INSERT OR IGNORE INTO model_groups (name, target_json, enabled, updated_at)
+             VALUES (?, ?, 1, datetime('now'))",
+        )
+        .bind(group.name)
+        .bind(serde_json::Value::Array(group.targets).to_string())
+        .execute(db)
+        .await;
+    }
+}
+
+struct SmartModelGroup {
+    name: &'static str,
+    targets: Vec<serde_json::Value>,
+}
+
+fn smart_model_groups() -> Vec<SmartModelGroup> {
+    vec![
+        SmartModelGroup {
+            name: "fast:chat",
+            targets: vec![
+                target("groq", "llama3-8b-8192"),
+                target("cerebras", "llama3.1-8b"),
+                target("google", "gemini-2.0-flash"),
+                target("ollama", "llama3.2"),
+            ],
+        },
+        SmartModelGroup {
+            name: "cheap:code",
+            targets: vec![
+                target("ollama", "qwen2.5-coder:7b"),
+                target("mistral", "open-mistral-nemo"),
+                target("siliconflow", "deepseek-ai/DeepSeek-V3"),
+            ],
+        },
+        SmartModelGroup {
+            name: "reasoning:deep",
+            targets: vec![
+                target("xai", "grok-4.20-reasoning"),
+                target("deepseek", "deepseek-v4-pro"),
+                target("siliconflow", "deepseek-ai/DeepSeek-V3"),
+            ],
+        },
+        SmartModelGroup {
+            name: "vision:balanced",
+            targets: vec![
+                target("google", "gemini-2.0-flash"),
+                target("github-models", "gpt-4o-mini"),
+            ],
+        },
+    ]
+}
+
+fn target(provider: &str, model: &str) -> serde_json::Value {
+    serde_json::json!({"provider": provider, "model": model})
+}
+
+fn infer_family(provider_id: &str, model_id: &str) -> String {
+    if model_id.contains("llama") {
+        "llama".to_string()
+    } else if model_id.contains("gemini") {
+        "gemini".to_string()
+    } else if model_id.contains("mistral") || model_id.contains("mixtral") {
+        "mistral".to_string()
+    } else if model_id.contains("deepseek") {
+        "deepseek".to_string()
+    } else if model_id.contains("qwen") {
+        "qwen".to_string()
+    } else if model_id.contains("grok") {
+        "grok".to_string()
+    } else if provider_id == "local" || provider_id == "ollama" {
+        "local".to_string()
+    } else {
+        "general".to_string()
+    }
+}
+
+fn infer_task_tags(
+    model_id: &str,
+    supports_reasoning: bool,
+    supports_embeddings: bool,
+) -> Vec<String> {
+    let mut tags = vec!["chat".to_string()];
+    if model_id.contains("code") || model_id.contains("coder") {
+        tags.push("code".to_string());
+    }
+    if supports_reasoning {
+        tags.push("reasoning".to_string());
+    }
+    if supports_embeddings {
+        tags.push("embeddings".to_string());
+    }
+    tags
+}
+
+fn infer_context_window(model_id: &str) -> Option<u64> {
+    if model_id.contains("32768") {
+        Some(32_768)
+    } else if model_id.contains("8192") || model_id.contains("8k") {
+        Some(8_192)
+    } else if model_id.contains("128k") || model_id.contains("128_000") {
+        Some(128_000)
+    } else if model_id.contains("gemini") {
+        Some(1_048_576)
+    } else if model_id.contains("grok-4") {
+        Some(2_000_000)
+    } else {
+        None
+    }
+}
+
+fn infer_vision(provider_id: &str, model_id: &str) -> bool {
+    model_id.contains("vision")
+        || model_id.contains("gpt-4o")
+        || model_id.contains("gemini")
+        || (provider_id == "google" && model_id.contains("flash"))
+}
+
+fn infer_reasoning(model_id: &str) -> bool {
+    model_id.contains("reason")
+        || model_id.contains("deepseek")
+        || model_id.contains("grok-4")
+        || model_id.contains("r1")
+}
+
+fn freshness(
+    metadata_source: Option<&str>,
+    provider_discovery_state: Option<&str>,
+    discovered_at: Option<&str>,
+    updated_at: Option<&str>,
+) -> CatalogFreshness {
+    if metadata_source == Some("curated") {
+        return CatalogFreshness::Curated;
+    }
+    match provider_discovery_state {
+        Some("disabled") => return CatalogFreshness::Disabled,
+        Some("error_last_attempt") => return CatalogFreshness::ErrorLastAttempt,
+        Some("never_discovered") => return CatalogFreshness::NeverDiscovered,
+        _ => {}
+    }
+    if discovered_at.is_none() && updated_at.is_none() {
+        return CatalogFreshness::Curated;
+    }
+    let Some(timestamp) = discovered_at.or(updated_at) else {
+        return CatalogFreshness::Curated;
+    };
+    if timestamp_is_stale(timestamp) {
+        CatalogFreshness::Stale
+    } else {
+        CatalogFreshness::Fresh
+    }
+}
+
+fn freshness_score(freshness: &CatalogFreshness) -> f64 {
+    match freshness {
+        CatalogFreshness::Fresh => 1.0,
+        CatalogFreshness::Curated => 0.75,
+        CatalogFreshness::Stale => 0.45,
+        CatalogFreshness::ErrorLastAttempt => 0.30,
+        CatalogFreshness::NeverDiscovered => 0.20,
+        CatalogFreshness::Disabled => 0.0,
+    }
+}
+
+fn timestamp_is_stale(timestamp: &str) -> bool {
+    let Ok(parsed) = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%d %H:%M:%S") else {
+        return false;
+    };
+    let updated_at = parsed.and_utc();
+    chrono::Utc::now()
+        .signed_duration_since(updated_at)
+        .num_hours()
+        > STALE_AFTER_HOURS
+}
+
+fn request_contains_image_input(request: &NormalizedChatRequest) -> bool {
+    request.messages.iter().any(|message| {
+        let Some(content) = &message.content else {
+            return false;
+        };
+        match content {
+            serde_json::Value::Array(parts) => parts.iter().any(|part| {
+                part.get("type").and_then(|value| value.as_str()) == Some("image_url")
+                    || part.get("image_url").is_some()
+            }),
+            serde_json::Value::Object(object) => object.contains_key("image_url"),
+            _ => false,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::openai::chat::{ChatMessage, NormalizedChatRequest};
+
+    #[test]
+    fn infers_intelligence_for_reasoning_and_vision_models() {
+        let reasoning =
+            infer_model_intelligence("xai", "grok-4.20-reasoning", None, false, None, None, None);
+        assert!(reasoning.supports_reasoning);
+        assert!(reasoning.task_tags.contains(&"reasoning".to_string()));
+
+        let vision =
+            infer_model_intelligence("google", "gemini-2.0-flash", None, false, None, None, None);
+        assert!(vision.supports_vision);
+        assert!(vision.modalities.contains(&"vision".to_string()));
+    }
+
+    #[test]
+    fn detects_vision_request_requirements() {
+        let request = NormalizedChatRequest {
+            model: "vision:balanced".into(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: Some(serde_json::json!([
+                    {"type": "text", "text": "what is this?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+                ])),
+                name: None,
+                tool_calls: None,
+                tool_call_id: None,
+            }],
+            temperature: None,
+            top_p: None,
+            max_tokens: Some(256),
+            stream: false,
+            stop: None,
+            presence_penalty: None,
+            frequency_penalty: None,
+            user: None,
+            response_format: None,
+            tools: None,
+            tool_choice: None,
+        };
+        assert!(ModelRequestRequirements::for_chat(&request).requires_vision);
+    }
+}

--- a/src/discovery/refresh.rs
+++ b/src/discovery/refresh.rs
@@ -72,6 +72,13 @@ async fn refresh_one(state: &AppState, provider_cfg: crate::config::schema::Prov
                     .endpoint_compatibility
                     .iter()
                     .any(|kind| kind == "embeddings");
+                let mut metadata = crate::discovery::model_intelligence::intelligence_metadata(
+                    &m.provider_id,
+                    &m.upstream_model_id,
+                    m.context_window,
+                    supports_embeddings,
+                );
+                metadata["source"] = serde_json::json!("discovered");
                 match sqlx::query(
                     "INSERT OR REPLACE INTO models (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, supports_embeddings, metadata_json, discovered_at, updated_at)
                      VALUES (?, ?, ?, 1, ?, ?, ?, ?, datetime('now'), datetime('now'))"
@@ -82,7 +89,7 @@ async fn refresh_one(state: &AppState, provider_cfg: crate::config::schema::Prov
                 .bind(m.free_tier)
                 .bind(supports_chat)
                 .bind(supports_embeddings)
-                .bind(serde_json::json!({"context_window": m.context_window}).to_string())
+                .bind(metadata.to_string())
                 .execute(&state.db)
                 .await
                 {

--- a/src/router/engine.rs
+++ b/src/router/engine.rs
@@ -3,6 +3,9 @@ use crate::api::openai::chat::*;
 use crate::api::openai::embeddings::*;
 use crate::app::state::AppState;
 use crate::config::schema::Config;
+use crate::discovery::model_intelligence::{
+    ModelRequestRequirements, filter_by_model_intelligence,
+};
 use crate::providers::registry::ProviderRegistry;
 use crate::providers::traits::{EndpointKind, ProviderContext, ProviderError};
 use crate::router::fallback::{FallbackDecision, should_fallback};
@@ -102,6 +105,8 @@ pub async fn route_chat_request(
         EndpointKind::ChatCompletions,
     )
     .await;
+    plan = filter_by_model_intelligence(plan, &state, ModelRequestRequirements::for_chat(&request))
+        .await;
     if request.tools.is_some() {
         plan = prioritize_for_tool_use(plan, &state).await;
     }

--- a/src/router/selection.rs
+++ b/src/router/selection.rs
@@ -382,9 +382,25 @@ async fn quality_and_context_score(
     attempt: &RouteAttempt,
     endpoint_kind: EndpointKind,
 ) -> (f64, f64) {
-    let caps = sqlx::query_as::<_, (bool, bool, bool, i64, Option<String>)>(
-        "SELECT supports_tools, supports_json_mode, supports_vision, priority, metadata_json
-         FROM models WHERE provider_id = ? AND upstream_model_id = ?",
+    let caps = sqlx::query_as::<
+        _,
+        (
+            bool,
+            bool,
+            bool,
+            bool,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ),
+    >(
+        "SELECT m.supports_tools, m.supports_json_mode, m.supports_vision, m.supports_embeddings,
+                m.priority, m.metadata_json, p.discovery_state, m.discovered_at, m.updated_at
+         FROM models m
+         LEFT JOIN providers p ON p.provider_id = m.provider_id
+         WHERE m.provider_id = ? AND m.upstream_model_id = ?",
     )
     .bind(&attempt.provider_id)
     .bind(&attempt.model_id)
@@ -392,29 +408,55 @@ async fn quality_and_context_score(
     .await
     .ok()
     .flatten()
-    .unwrap_or((true, true, false, 100, None));
+    .unwrap_or((true, true, false, false, 100, None, None, None, None));
+
+    let intelligence = crate::discovery::model_intelligence::infer_model_intelligence(
+        &attempt.provider_id,
+        &attempt.model_id,
+        caps.5.as_deref(),
+        caps.3,
+        caps.6.as_deref(),
+        caps.7.as_deref(),
+        caps.8.as_deref(),
+    );
 
     let provider_quality =
         (tool_reliability_rank(&attempt.provider_id) as f64 / 100.0).clamp(0.0, 1.0);
     let capability_score = match endpoint_kind {
         EndpointKind::ChatCompletions => {
-            (if caps.0 { 0.35 } else { 0.0 })
-                + (if caps.1 { 0.25 } else { 0.0 })
-                + (if caps.2 { 0.10 } else { 0.0 })
+            (if caps.0 { 0.30 } else { 0.0 })
+                + (if caps.1 { 0.20 } else { 0.0 })
+                + (if caps.2 || intelligence.supports_vision {
+                    0.10
+                } else {
+                    0.0
+                })
+                + (if intelligence.supports_reasoning {
+                    0.10
+                } else {
+                    0.0
+                })
                 + 0.30
         }
-        EndpointKind::Embeddings => 0.65,
+        EndpointKind::Embeddings => {
+            if caps.3 || intelligence.supports_embeddings {
+                0.75
+            } else {
+                0.25
+            }
+        }
         EndpointKind::ModelList => 0.50,
     };
-    let model_priority_score = 1.0 / (1.0 + caps.3.max(0) as f64 / 100.0);
+    let model_priority_score = 1.0 / (1.0 + caps.4.max(0) as f64 / 100.0);
 
-    let context_score = context_score(caps.4.as_deref());
+    let context_score = context_score(caps.5.as_deref());
 
     (
         (provider_quality * 0.40
-            + capability_score * 0.30
+            + capability_score * 0.25
             + model_priority_score * 0.15
-            + context_score * 0.15)
+            + context_score * 0.10
+            + intelligence.freshness_score * 0.10)
             .clamp(0.0, 1.0),
         context_score,
     )

--- a/src/ui/routes.rs
+++ b/src/ui/routes.rs
@@ -811,7 +811,7 @@ pub async fn render_models(state: &AppState) -> String {
             <div class="p-0 overflow-x-auto min-h-[300px]">
                 <table class="w-full text-left">
                     <thead class="text-slate-500 border-b border-white/5 bg-white/[0.01]">
-                        <tr><th>Model ID</th><th>Provider</th><th>Status</th><th>Priority</th><th>Actions</th></tr>
+                        <tr><th>Model ID</th><th>Provider</th><th>Intelligence</th><th>Freshness</th><th>Status</th><th>Priority</th><th>Actions</th></tr>
                     </thead>
                     <tbody id="modelsTableBody" class="divide-y divide-white/5">{}</tbody>
                 </table>
@@ -845,7 +845,7 @@ pub async fn render_models(state: &AppState) -> String {
     }}
 
     function setModelStatus(message) {{
-        document.getElementById('modelsTableBody').innerHTML = `<tr><td colspan="5" class="px-6 py-4 text-center text-slate-500">${{message}}</td></tr>`;
+        document.getElementById('modelsTableBody').innerHTML = `<tr><td colspan="7" class="px-6 py-4 text-center text-slate-500">${{message}}</td></tr>`;
         document.getElementById('pageInfo').innerText = '';
     }}
 
@@ -884,11 +884,17 @@ pub async fn render_models(state: &AppState) -> String {
 
         let html = '';
         if (slice.length === 0) {{
-            html = `<tr><td colspan="5" class="px-6 py-4 text-center text-slate-500">No models found</td></tr>`;
+            html = `<tr><td colspan="7" class="px-6 py-4 text-center text-slate-500">No models found</td></tr>`;
         }} else {{
             slice.forEach(m => {{
                 const u = m.upstream_model_id || '?';
                 const p = m.provider_id || '?';
+                const intel = m.intelligence || {{}};
+                const tags = (intel.task_tags || []).slice(0, 3).map(t => `<span class="text-[10px] px-1.5 py-0.5 rounded bg-cyan-500/10 text-cyan-300 border border-cyan-500/10">${{t}}</span>`).join('');
+                const modalities = (intel.modalities || []).map(t => `<span class="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-300 border border-emerald-500/10">${{t}}</span>`).join('');
+                const context = intel.context_window ? `${{Number(intel.context_window).toLocaleString()}} ctx` : 'unknown ctx';
+                const freshness = m.freshness || intel.freshness || 'Unknown';
+                const freshnessScore = Math.round((m.freshness_score || intel.freshness_score || 0) * 100);
                 const enabled = m.enabled !== false;
                 const next_enabled = !enabled;
                 const button_label = enabled ? "Disable" : "Enable";
@@ -897,7 +903,7 @@ pub async fn render_models(state: &AppState) -> String {
                 const status_html = enabled 
                     ? `<span class="px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-500 text-[10px]">Enabled</span>`
                     : `<span class="px-2 py-0.5 rounded bg-white/5 text-slate-500 text-[10px]">Disabled</span>`;
-                html += `<tr><td class="font-mono text-sm text-cyan-400">${{u}}</td><td class="text-sm">${{p}}</td><td>${{status_html}}</td><td><input type="number" value="${{prio}}" class="w-16 bg-black/20 border border-white/10 rounded px-2 py-0.5 text-xs text-center" onchange="updateModelPriority('${{p.replace(/'/g, "\\'")}}','${{u.replace(/'/g, "\\'")}}', this.value)"></td><td><button class="${{button_class}}" onclick="toggleModel('${{p.replace(/'/g, "\\'")}}','${{u.replace(/'/g, "\\'")}}',${{next_enabled}})">${{button_label}}</button></td></tr>`;
+                html += `<tr><td class="font-mono text-sm text-cyan-400">${{u}}<div class="text-[10px] text-slate-500 mt-1">${{intel.family || 'general'}} · ${{context}}</div></td><td class="text-sm">${{p}}</td><td><div class="flex flex-wrap gap-1 max-w-xs">${{tags}}${{modalities}}</div></td><td class="text-xs"><span class="text-slate-300">${{freshness}}</span><div class="text-[10px] text-slate-500">${{freshnessScore}}%</div></td><td>${{status_html}}</td><td><input type="number" value="${{prio}}" class="w-16 bg-black/20 border border-white/10 rounded px-2 py-0.5 text-xs text-center" onchange="updateModelPriority('${{p.replace(/'/g, "\\'")}}','${{u.replace(/'/g, "\\'")}}', this.value)"></td><td><button class="${{button_class}}" onclick="toggleModel('${{p.replace(/'/g, "\\'")}}','${{u.replace(/'/g, "\\'")}}',${{next_enabled}})">${{button_label}}</button></td></tr>`;
             }});
         }}
         document.getElementById('modelsTableBody').innerHTML = html;
@@ -921,10 +927,10 @@ pub async fn render_models(state: &AppState) -> String {
 
 fn render_initial_model_rows(models: &serde_json::Value) -> String {
     let Some(models) = models.get("models").and_then(|value| value.as_array()) else {
-        return r#"<tr><td colspan="5" class="px-6 py-4 text-center text-slate-500">No models found</td></tr>"#.to_string();
+        return r#"<tr><td colspan="7" class="px-6 py-4 text-center text-slate-500">No models found</td></tr>"#.to_string();
     };
     if models.is_empty() {
-        return r#"<tr><td colspan="5" class="px-6 py-4 text-center text-slate-500">No models found</td></tr>"#.to_string();
+        return r#"<tr><td colspan="7" class="px-6 py-4 text-center text-slate-500">No models found</td></tr>"#.to_string();
     }
 
     models
@@ -951,14 +957,33 @@ fn render_initial_model_rows(models: &serde_json::Value) -> String {
                 .get("priority")
                 .and_then(|value| value.as_i64())
                 .unwrap_or(100);
+            let intelligence = model.get("intelligence").unwrap_or(&serde_json::Value::Null);
+            let family = escape_html(
+                intelligence
+                    .get("family")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("general"),
+            );
+            let context = intelligence
+                .get("context_window")
+                .and_then(|value| value.as_u64())
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            let freshness = escape_html(
+                model
+                    .get("freshness")
+                    .or_else(|| intelligence.get("freshness"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("Unknown"),
+            );
             let status = if enabled {
                 r#"<span class="px-2 py-0.5 rounded bg-emerald-500/10 text-emerald-500 text-[10px]">Enabled</span>"#
             } else {
                 r#"<span class="px-2 py-0.5 rounded bg-white/5 text-slate-500 text-[10px]">Disabled</span>"#
             };
             format!(
-                r#"<tr><td class="font-mono text-sm text-cyan-400">{}</td><td class="text-sm">{}</td><td>{}</td><td class="text-sm">{}</td><td class="text-xs text-slate-500">Loading...</td></tr>"#,
-                upstream, provider, status, priority
+                r#"<tr><td class="font-mono text-sm text-cyan-400">{}<div class="text-[10px] text-slate-500 mt-1">{} · {} ctx</div></td><td class="text-sm">{}</td><td class="text-xs text-slate-500">Loading...</td><td class="text-xs">{}</td><td>{}</td><td class="text-sm">{}</td><td class="text-xs text-slate-500">Loading...</td></tr>"#,
+                upstream, family, context, provider, freshness, status, priority
             )
         })
         .collect::<Vec<_>>()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -57,7 +57,10 @@ async fn build_test_app() -> (axum::Router, AppState) {
             axum::routing::post(routes::chat_completions),
         )
         .route("/v1/embeddings", axum::routing::post(routes::embeddings))
-        .route("/admin/config", axum::routing::get(routes::admin_config))
+        .route(
+            "/admin/config",
+            axum::routing::get(routes::admin_config).put(routes::admin_config_save),
+        )
         .with_state(state.clone());
 
     (router, state)
@@ -2424,6 +2427,177 @@ async fn test_policy_quality_first_agentic_harness_prefers_tool_json_capable_rou
 
     assert_eq!(planned[0].provider_id, "groq");
     assert_eq!(planned[0].model_id, "hermes-agentic-tools");
+}
+
+#[tokio::test]
+async fn test_model_intelligence_filters_context_and_vision_requirements() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    let state = AppState::new(
+        Config::default(),
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    );
+    seed_policy_provider_model(&state, "small", "model", true, 100, true, true).await;
+    seed_policy_provider_model(&state, "vision", "model", true, 100, true, true).await;
+    sqlx::query("UPDATE models SET metadata_json = ?, supports_vision = ? WHERE provider_id = ?")
+        .bind(serde_json::json!({"context_window": 4096}).to_string())
+        .bind(false)
+        .bind("small")
+        .execute(&state.db)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE models SET metadata_json = ?, supports_vision = ? WHERE provider_id = ?")
+        .bind(serde_json::json!({"context_window": 128000, "supports_vision": true}).to_string())
+        .bind(true)
+        .bind("vision")
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+    let plan = vec![
+        tokenscavenger::router::selection::RouteAttempt {
+            provider_id: "small".into(),
+            model_id: "model".into(),
+            priority: 0,
+        },
+        tokenscavenger::router::selection::RouteAttempt {
+            provider_id: "vision".into(),
+            model_id: "model".into(),
+            priority: 1,
+        },
+    ];
+
+    let filtered = tokenscavenger::discovery::model_intelligence::filter_by_model_intelligence(
+        plan,
+        &state,
+        tokenscavenger::discovery::model_intelligence::ModelRequestRequirements {
+            requires_tools: false,
+            requires_json_mode: false,
+            requires_vision: true,
+            required_context_tokens: Some(10_000),
+        },
+    )
+    .await;
+
+    assert_eq!(filtered.len(), 1);
+    assert_eq!(filtered[0].provider_id, "vision");
+}
+
+#[tokio::test]
+async fn test_smart_model_groups_are_seeded_without_overwriting_operator_groups() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    sqlx::query(
+        "INSERT INTO model_groups (name, target_json, enabled) VALUES ('fast:chat', '[\"operator-model\"]', 1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    tokenscavenger::discovery::model_intelligence::seed_smart_model_groups(&pool).await;
+
+    let fast = sqlx::query_as::<_, (String,)>(
+        "SELECT target_json FROM model_groups WHERE name = 'fast:chat'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    let reasoning = sqlx::query_as::<_, (String,)>(
+        "SELECT target_json FROM model_groups WHERE name = 'reasoning:deep'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(fast.0, "[\"operator-model\"]");
+    assert!(reasoning.0.contains("grok-4.20-reasoning"));
+}
+
+#[tokio::test]
+async fn test_public_model_list_includes_intelligence_metadata() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+
+    let state = AppState::new(
+        Config::default(),
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    );
+    seed_policy_provider_model(&state, "google", "gemini-2.0-flash", true, 100, true, true).await;
+
+    let response = tokenscavenger::discovery::merge::build_model_list(&state).await;
+    let gemini = response
+        .data
+        .iter()
+        .find(|model| {
+            model.provider_id.as_deref() == Some("google") && model.id == "gemini-2.0-flash"
+        })
+        .expect("gemini model present");
+
+    assert!(gemini.context_window.is_some());
+    assert!(
+        gemini
+            .modalities
+            .as_ref()
+            .is_some_and(|modalities| modalities.contains(&"vision".to_string()))
+    );
+    assert!(gemini.freshness.is_some());
+}
+
+#[tokio::test]
+async fn test_admin_config_save_updates_model_intelligence_overrides() {
+    let (app, state) = build_test_app().await;
+    seed_policy_provider_model(&state, "mock", "plain", true, 100, true, true).await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/admin/config")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "models": [{
+                            "provider_id": "mock",
+                            "model_id": "plain",
+                            "supports_vision": true,
+                            "metadata": {
+                                "context_window": 64000,
+                                "task_tags": ["chat", "vision"]
+                            }
+                        }]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let row = sqlx::query_as::<_, (bool, String)>(
+        "SELECT supports_vision, metadata_json FROM models WHERE provider_id = 'mock' AND upstream_model_id = 'plain'",
+    )
+    .fetch_one(&state.db)
+    .await
+    .unwrap();
+    assert!(row.0);
+    assert!(row.1.contains("64000"));
 }
 
 async fn seed_policy_provider_model(


### PR DESCRIPTION
## Summary
- Adds a Model Intelligence Layer for normalized model family, task tags, modalities, context-window metadata, reasoning/vision/tool/JSON signals, embeddings support, and catalog freshness scoring.
- Seeds editable smart model groups: `fast:chat`, `cheap:code`, `reasoning:deep`, and `vision:balanced`.
- Applies model intelligence compatibility filtering to chat and streaming route plans before upstream calls for tools, JSON mode, vision input, and known context-window requirements.
- Exposes intelligence metadata through `/v1/models`, `/admin/models`, route-plan diagnostics, and the Models UI.
- Updates README, roadmap, API/config docs, changelog, and deterministic coverage.

## Why
Roadmap item 3 asks TokenScavenger to become the map between task intent and concrete provider models. This implementation keeps the runtime self-hosted and single-binary while giving operators richer model comparison and safer pre-upstream routing decisions.

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `git diff --check`
- Focused tests for model intelligence compatibility, smart group seeding, public model metadata, and admin capability overrides
- Live Ollama smoke with isolated temp config/db: `/v1/models`, real `phi4-mini:latest` chat completion, and vision incompatibility route-plan check
- Live configured-provider smoke with isolated temp config/db: ready with 2 configured providers, 210-model catalog carrying freshness/task/modality metadata, and `fast:chat` route-plan selecting Groq first

## Notes
- `.dev/` was intentionally not staged or committed per project instruction.
- Smart groups use `INSERT OR IGNORE`, so operator-edited groups are not overwritten on startup.