### PR TITLE
Implement observability incident workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added an operator-grade observability workflow with durable request trace
+  timelines, time-window success/429/fallback/token/cost analytics, an incident
+  feed, redacted diagnostic bundle export, and `/ui/observability`.
+- Added ready-to-import Grafana dashboard and Prometheus alert starters under
+  `monitoring/`.
+
 ### Changed
+
+- Updated the roadmap status for the shipped v0.2.0 policy engine tidy-up.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@
 - **Full OpenAI-compatible API** (chat completions + streaming SSE, embeddings, `/v1/models`)
 - **18 built-in providers** with automatic model discovery, including local OpenAI-compatible upstreams
 - **Circuit breakers, retries & health monitoring**
-- **Prometheus metrics** + per-provider token usage tracking
-- **Embedded web UI** with live dashboard, logs, and config editor
+- **Prometheus metrics**, request traces, incident feed, and diagnostic bundles
+- **Embedded web UI** with live dashboard, observability, logs, and config editor
 - **SQLite persistence** (WAL mode) for usage accounting and audit log
 - **Interactive setup wizard** and CLI tools
 - **Single static binary** (~15–25 MB)
@@ -51,6 +51,8 @@
 | `GET /healthz`, `GET /readyz` | Health and readiness probes                                 |
 | `GET /metrics`                | Prometheus metrics                                          |
 | `GET /ui`                     | Embedded operator dashboard                                 |
+| `GET /admin/request-traces`   | Recent request trace summaries                              |
+| `GET /admin/incidents`        | Incident feed from health, config, and routing events       |
 
 Error responses use the OpenAI-style `{"error": ...}` envelope. Upstream rate-limit exhaustion returns `429` with `rate_limit_exceeded` and `Retry-After` when known; non-rate-limit route exhaustion remains `503 route_exhausted`. See [API behavior](documentation/api-behavior.md) for the full status-code contract.
 
@@ -308,6 +310,7 @@ Open `http://localhost:8000/ui` in your browser for the operator dashboard with 
 - Models — compare discovered and curated models with intelligence metadata
 - Routing — view fallback order and smart/custom model group configuration
 - Usage — token counts and estimated costs
+- Observability — request traces, incident feed, and diagnostic bundle export
 - Health — per-provider health states
 - Logs — real-time log stream via SSE
 - Config — view and edit current effective configuration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ This roadmap is intentionally focused on five high-value enhancements. Each one 
 
 ## 1. Policy Engine For Cost, Latency, And Quality
 
-**Status:** Implemented in `feature/policy-engine-cost-latency-quality`.
+**Status:** Implemented in v0.2.0.
 
 **Current baseline:** TokenScavenger already has provider ordering, model enablement, free-first routing, explicit paid fallback gating, retries, health checks, circuit breakers, usage accounting, and estimated cost surfaces.
 
@@ -52,17 +52,19 @@ This roadmap is intentionally focused on five high-value enhancements. Each one 
 
 ## 4. Operator-Grade Observability And Incident Workflow
 
+**Status:** Implemented in v0.3.3.
+
 **Current baseline:** TokenScavenger already exposes Prometheus metrics, structured logs, usage views, health views, audit history, route-plan explanations, live log streaming, and documented 429/503 response behavior.
 
 **Why it matters:** A router is only as useful as its explanations. When an app sees slow requests, 429s, or degraded quality, TokenScavenger should make the cause obvious in seconds.
 
 **What good looks like:**
 
-- A request trace view that shows model group resolution, candidate providers, skip reasons, retries, selected route, upstream response class, latency, and token usage.
-- Deeper time-window analytics for success rate, 429 rate, cost estimate, token volume, fallback count, and provider saturation.
-- Incident annotations for provider outages, quota exhaustion, config changes, and breaker transitions.
-- Exportable diagnostic bundles with secrets redacted.
-- Ready-to-import Grafana dashboards and alerting rules built on the existing Prometheus metrics.
+- [x] A request trace view that shows model group resolution, candidate providers, skip reasons, retries, selected route, upstream response class, latency, and token usage.
+- [x] Deeper time-window analytics for success rate, 429 rate, cost estimate, token volume, fallback count, and provider saturation.
+- [x] Incident annotations for provider outages, quota exhaustion, config changes, and breaker transitions.
+- [x] Exportable diagnostic bundles with secrets redacted.
+- [x] Ready-to-import Grafana dashboards and alerting rules built on the existing Prometheus metrics.
 
 ## 5. Deployment, Security, And Team Controls
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,38 +5,38 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="title"
-      content="TokenScavenger v0.3.0 | Local-first LLM Routing"
+      content="TokenScavenger v0.3.3 | Observable LLM Routing"
     />
     <meta
       name="description"
-      content="TokenScavenger v0.3.0 adds local OpenAI-compatible provider routing for Ollama, llama.cpp, LM Studio, and generic local servers alongside free-tier and paid fallback providers."
+      content="TokenScavenger v0.3.3 adds request traces, incident workflow, redacted diagnostic bundles, and Grafana/Prometheus starters to local-first LLM routing."
     />
     <meta name="robots" content="index, follow" />
     <link rel="icon" type="image/png" href="assets/TokenScavengerLogo.png" />
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="TokenScavenger v0.3.0 | Local-first LLM Routing"
+      content="TokenScavenger v0.3.3 | Observable LLM Routing"
     />
     <meta
       property="og:description"
-      content="Route local Ollama, llama.cpp, LM Studio, free-tier providers, and explicit paid fallback through one self-hosted OpenAI-compatible gateway."
+      content="Route local, free-tier, and explicit paid fallback models through one self-hosted gateway with request traces and incident diagnostics."
     />
     <meta
       property="og:image"
       content="/assets/token-scavenger-v0.3.0-local-release.png"
     />
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:title" content="TokenScavenger v0.3.0" />
+    <meta property="twitter:title" content="TokenScavenger v0.3.3" />
     <meta
       property="twitter:description"
-      content="Now with local OpenAI-compatible providers: Ollama, llama.cpp, LM Studio, and generic local upstreams."
+      content="Now with request traces, incident workflow, redacted diagnostic bundles, and Grafana/Prometheus starters."
     />
     <meta
       property="twitter:image"
       content="/assets/token-scavenger-v0.3.0-local-release.png"
     />
-    <title>TokenScavenger v0.3.0 | Local-first LLM Routing</title>
+    <title>TokenScavenger v0.3.3 | Observable LLM Routing</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -178,9 +178,9 @@
               gateway.
             </h1>
             <p class="mt-6 max-w-xl text-lg leading-8 text-slate-300">
-              TokenScavenger v0.3.0 routes Ollama, llama.cpp, LM Studio, local
-              OpenAI-compatible servers, free-tier providers, and explicit paid
-              fallback through one self-hosted Rust gateway.
+              TokenScavenger v0.3.3 routes local, free-tier, and explicit paid
+              fallback providers with durable request traces, incident
+              diagnostics, and redacted support bundles.
             </p>
             <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
               <a
@@ -214,8 +214,8 @@
                   Live status
                 </p>
                 <p class="mt-1 text-sm text-slate-300">
-                  Local and remote providers share health, fallback, and
-                  metrics.
+                  Local and remote providers share health, fallback, metrics,
+                  traces, and incident workflow.
                 </p>
               </div>
               <div
@@ -349,7 +349,7 @@
               </p>
               <pre
                 class="mt-6 min-w-0 overflow-x-auto rounded-2xl bg-slate-950/80 p-5 text-sm leading-6 text-slate-200"
-              ><code>VERSION=v0.3.0
+              ><code>VERSION=v0.3.3
 curl -LO https://github.com/kabudu/token-scavenger/releases/download/$VERSION/tokenscavenger-$VERSION-aarch64-apple-darwin.zip
 unzip tokenscavenger-$VERSION-aarch64-apple-darwin.zip
 ./tokenscavenger</code></pre>
@@ -369,7 +369,7 @@ unzip tokenscavenger-$VERSION-aarch64-apple-darwin.zip
               </p>
               <pre
                 class="mt-6 min-w-0 overflow-x-auto rounded-2xl bg-slate-950/80 p-5 text-sm leading-6 text-slate-200"
-              ><code>VERSION=v0.3.0
+              ><code>VERSION=v0.3.3
 curl -LO https://github.com/kabudu/token-scavenger/releases/download/$VERSION/tokenscavenger-$VERSION-x86_64-unknown-linux-gnu
 chmod +x tokenscavenger-$VERSION-x86_64-unknown-linux-gnu
 ./tokenscavenger-$VERSION-x86_64-unknown-linux-gnu</code></pre>
@@ -389,7 +389,7 @@ chmod +x tokenscavenger-$VERSION-x86_64-unknown-linux-gnu
               </p>
               <pre
                 class="mt-6 min-w-0 max-w-full whitespace-pre-wrap break-all rounded-2xl bg-slate-950/80 p-5 text-sm leading-6 text-slate-200"
-              ><code class="whitespace-pre-wrap break-all">$Version = "v0.3.0"
+              ><code class="whitespace-pre-wrap break-all">$Version = "v0.3.3"
 $Url = "https://github.com/kabudu/token-scavenger/releases/download/$Version/tokenscavenger-$Version-x86_64-pc-windows-msvc.exe"
 Invoke-WebRequest `
   -Uri $Url `
@@ -505,8 +505,8 @@ Invoke-WebRequest `
               class="mt-4 mx-auto max-w-2xl text-base leading-7 text-slate-400"
             >
               Tokens are the new currency of the AI era. TokenScavenger keeps
-              local, free-tier, and approved paid routes observable and under
-              operator control.
+              local, free-tier, and approved paid routes observable, explainable,
+              and under operator control.
             </p>
           </div>
           <div class="grid gap-8 lg:grid-cols-4">
@@ -532,12 +532,12 @@ Invoke-WebRequest `
             </article>
             <article class="feature-card rounded-3xl p-8">
               <h3 class="text-xl font-semibold text-white">
-                Smart circuit breakers
+                Incident workflow
               </h3>
               <p class="mt-4 text-slate-300">
-                Automatically detect provider failures and route traffic to the
-                best available local or free provider without client-side
-                changes.
+                Trace every request, inspect provider incidents, and export
+                redacted diagnostic bundles when production traffic slows down
+                or starts hitting 429s.
               </p>
             </article>
             <article class="feature-card rounded-3xl p-8">

--- a/documentation/api-behavior.md
+++ b/documentation/api-behavior.md
@@ -13,6 +13,11 @@ TokenScavenger exposes OpenAI-compatible HTTP endpoints while routing each reque
 | `GET /readyz` | Readiness check with dependency state. |
 | `GET /metrics` | Prometheus metrics. |
 | `GET /ui` | Embedded operator dashboard, when enabled. |
+| `GET /admin/observability/summary` | Time-window success, 429, fallback, token, cost, and provider saturation summary. |
+| `GET /admin/request-traces` | Recent request trace summaries. |
+| `GET /admin/request-traces/{request_id}` | Detailed route timeline, usage, and request outcome for one request. |
+| `GET /admin/incidents` | Incident feed derived from provider health events, route failures, and config audit history. |
+| `GET /admin/diagnostics/bundle` | Redacted diagnostic bundle for support and incident handoff. |
 
 ## Error Shape
 
@@ -80,6 +85,26 @@ Useful metrics include:
 - `tokenscavenger_provider_health_state`
 - `tokenscavenger_provider_breaker_state`
 - `tokenscavenger_quota_remaining`
+
+## Observability And Incident Workflow
+
+Every routed request receives a durable trace timeline in SQLite. Trace events
+record the model group resolution, planned candidates, skip reasons, attempts,
+retry/fallback decisions, upstream response class, latency, and usage linkage.
+Request and diagnostic endpoints never include request bodies and apply the same
+secret redaction used by the admin config API.
+
+Useful triage endpoints:
+
+```bash
+curl http://localhost:8000/admin/observability/summary?period=24h
+curl http://localhost:8000/admin/request-traces?limit=25
+curl http://localhost:8000/admin/request-traces/<request-id>
+curl http://localhost:8000/admin/incidents?limit=25
+curl http://localhost:8000/admin/diagnostics/bundle
+```
+
+The embedded UI exposes the same workflow at `/ui/observability`.
 
 ## Model Intelligence
 

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -201,6 +201,21 @@ Usage and health event data accumulates over time. The default schema includes t
 
 ## Monitoring
 
+### Incident Workflow
+
+The embedded UI includes `/ui/observability` for request traces, incident feed
+review, and redacted diagnostic bundle export. The backing admin endpoints are:
+
+- `GET /admin/observability/summary?period=24h`
+- `GET /admin/request-traces?limit=50`
+- `GET /admin/request-traces/{request_id}`
+- `GET /admin/incidents?limit=50`
+- `GET /admin/diagnostics/bundle`
+
+Diagnostic bundles include runtime version, redacted effective config, recent
+request traces, incidents, health states, and 24-hour observability summary.
+They do not include provider API keys or full request/response bodies.
+
 ### Prometheus Metrics
 
 Available at `GET /metrics`:
@@ -213,6 +228,11 @@ Available at `GET /metrics`:
 | `tokenscavenger_route_attempts_total` | Counter | provider, model, outcome | Route attempt outcomes |
 | `tokenscavenger_provider_health_state` | Gauge | provider, state | Current health state per provider |
 | `tokenscavenger_provider_breaker_state` | Gauge | provider, state | Circuit breaker state per provider |
+
+Ready-to-import monitoring starters live in `monitoring/`:
+
+- `monitoring/grafana-dashboard.json`
+- `monitoring/prometheus-alerts.yml`
 
 ### Logging
 

--- a/monitoring/grafana-dashboard.json
+++ b/monitoring/grafana-dashboard.json
@@ -1,0 +1,89 @@
+{
+  "title": "TokenScavenger Observability",
+  "uid": "tokenscavenger-observability",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "tags": ["tokenscavenger", "llm-router"],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Requests",
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
+      "targets": [
+        {"expr": "sum(rate(tokenscavenger_requests_total[5m]))", "legendFormat": "rps"}
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "429 Rate",
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 4},
+      "targets": [
+        {"expr": "sum(rate(tokenscavenger_requests_total{status=~\"rate_limited|quota_exhausted\"}[5m])) / clamp_min(sum(rate(tokenscavenger_requests_total[5m])), 0.001)", "legendFormat": "429 ratio"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "percentunit"}}
+    },
+    {
+      "type": "stat",
+      "title": "Estimated Spend",
+      "gridPos": {"x": 12, "y": 0, "w": 6, "h": 4},
+      "targets": [
+        {"expr": "sum(increase(tokenscavenger_estimated_cost_usd_total[24h]))", "legendFormat": "USD"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "currencyUSD"}}
+    },
+    {
+      "type": "stat",
+      "title": "Open Breakers",
+      "gridPos": {"x": 18, "y": 0, "w": 6, "h": 4},
+      "targets": [
+        {"expr": "sum(tokenscavenger_provider_breaker_state{state=~\"open|half_open\"})", "legendFormat": "breakers"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests By Provider",
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "sum by (provider, status) (rate(tokenscavenger_requests_total[5m]))", "legendFormat": "{{provider}} {{status}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Route Attempt Outcomes",
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "sum by (provider, outcome) (rate(tokenscavenger_route_attempts_total[5m]))", "legendFormat": "{{provider}} {{outcome}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Token Volume",
+      "gridPos": {"x": 0, "y": 12, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "sum by (provider, type) (rate(tokenscavenger_tokens_total[5m]))", "legendFormat": "{{provider}} {{type}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Latency",
+      "gridPos": {"x": 12, "y": 12, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "sum by (provider, endpoint) (rate(tokenscavenger_request_latency_seconds_sum[5m])) / clamp_min(sum by (provider, endpoint) (rate(tokenscavenger_request_latency_seconds_count[5m])), 0.001)", "legendFormat": "{{provider}} {{endpoint}}"}
+      ],
+      "fieldConfig": {"defaults": {"unit": "s"}}
+    },
+    {
+      "type": "table",
+      "title": "Provider Health",
+      "gridPos": {"x": 0, "y": 20, "w": 24, "h": 6},
+      "targets": [
+        {"expr": "tokenscavenger_provider_health_state", "legendFormat": "{{provider}} {{state}}", "format": "table", "instant": true}
+      ]
+    }
+  ]
+}

--- a/monitoring/prometheus-alerts.yml
+++ b/monitoring/prometheus-alerts.yml
@@ -1,0 +1,40 @@
+groups:
+  - name: tokenscavenger.incidents
+    rules:
+      - alert: TokenScavengerHighRateLimitRate
+        expr: |
+          sum(rate(tokenscavenger_requests_total{status=~"rate_limited|quota_exhausted"}[5m]))
+          / clamp_min(sum(rate(tokenscavenger_requests_total[5m])), 0.001) > 0.10
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: TokenScavenger is seeing elevated 429/quota responses
+          description: More than 10% of recent requests are rate-limited or quota-exhausted.
+
+      - alert: TokenScavengerProviderBreakerOpen
+        expr: sum by (provider) (tokenscavenger_provider_breaker_state{state=~"open|half_open"}) > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: TokenScavenger provider circuit breaker is open
+          description: Provider {{ $labels.provider }} has an open or half-open breaker.
+
+      - alert: TokenScavengerNoSuccessfulRequests
+        expr: sum(rate(tokenscavenger_requests_total{status="success"}[10m])) == 0 and sum(rate(tokenscavenger_requests_total[10m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: TokenScavenger has traffic but no successful requests
+          description: All recent routed requests are failing.
+
+      - alert: TokenScavengerUnknownPaidPricing
+        expr: increase(tokenscavenger_usage_unknown_price_total[1h]) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: TokenScavenger recorded paid usage without known pricing
+          description: Cost accounting is using fallback estimates for at least one paid provider/model.

--- a/src/api/openai/stream.rs
+++ b/src/api/openai/stream.rs
@@ -186,6 +186,7 @@ pub async fn create_chat_stream(
     request: NormalizedChatRequest,
     request_id: String,
 ) -> Result<impl Stream<Item = Result<Event, Infallible>>, ApiError> {
+    let started_at = Instant::now();
     let config = state.config();
     let registry = &state.provider_registry;
     let policy = RoutePolicy::from_config(&config);
@@ -203,6 +204,7 @@ pub async fn create_chat_stream(
         .iter()
         .map(|target| target.label())
         .collect::<Vec<_>>();
+    let resolved_model_label = resolved_models.join(", ");
 
     // Build attempt plan
     let mut plan = Vec::new();
@@ -215,6 +217,30 @@ pub async fn create_chat_stream(
     assign_attempt_priorities(&mut plan);
 
     if plan.is_empty() {
+        crate::observability::record_route_plan(
+            &state,
+            &request_id,
+            "chat",
+            &request.model,
+            &resolved_models,
+            &plan,
+        )
+        .await;
+        let _ = crate::usage::accounting::record_failure(
+            &state,
+            crate::usage::accounting::FailureRecord {
+                request_id: &request_id,
+                endpoint_kind: "chat",
+                requested_model: &request.model,
+                selected_provider_id: None,
+                selected_model_id: None,
+                status: "route_exhausted",
+                http_status: 503,
+                latency_ms: started_at.elapsed().as_millis() as i64,
+                streaming: true,
+            },
+        )
+        .await;
         return Err(ApiError::RouteExhausted(format!(
             "No available providers for streaming model(s): {:?}",
             resolved_models
@@ -249,6 +275,30 @@ pub async fn create_chat_stream(
     .await;
 
     if plan.is_empty() {
+        crate::observability::record_route_plan(
+            &state,
+            &request_id,
+            "chat",
+            &request.model,
+            &resolved_models,
+            &plan,
+        )
+        .await;
+        let _ = crate::usage::accounting::record_failure(
+            &state,
+            crate::usage::accounting::FailureRecord {
+                request_id: &request_id,
+                endpoint_kind: "chat",
+                requested_model: &request.model,
+                selected_provider_id: None,
+                selected_model_id: Some(&resolved_model_label),
+                status: "route_exhausted",
+                http_status: 503,
+                latency_ms: started_at.elapsed().as_millis() as i64,
+                streaming: true,
+            },
+        )
+        .await;
         return Err(ApiError::RouteExhausted(format!(
             "All providers for streaming model(s) '{:?}' are unavailable, disabled, or paid fallback is disabled",
             resolved_models
@@ -261,6 +311,15 @@ pub async fn create_chat_stream(
         plan = ?plan.iter().map(|p| p.label()).collect::<Vec<_>>(),
         "Stream route plan built"
     );
+    crate::observability::record_route_plan(
+        &state,
+        &request_id,
+        "chat",
+        &request.model,
+        &resolved_models,
+        &plan,
+    )
+    .await;
 
     // Create a channel for streaming events
     let (tx, mut rx) = tokio::sync::mpsc::channel::<StreamEvent>(256);
@@ -272,6 +331,8 @@ pub async fn create_chat_stream(
     let usage_context: Arc<Mutex<Option<StreamUsageContext>>> = Arc::new(Mutex::new(None));
     let task_usage_context = usage_context.clone();
     let usage_state = state.clone();
+    let task_request_id = request_id.clone();
+    let task_started_at = started_at;
 
     tokio::spawn(async move {
         let pre_content_timeout =
@@ -281,12 +342,36 @@ pub async fn create_chat_stream(
             let provider_id = &attempt.provider_id;
             let model_id = &attempt.model_id;
             if should_skip_for_context_hint(&state, attempt, prompt_size_hint) {
+                crate::observability::record_skip(
+                    &state,
+                    &task_request_id,
+                    "chat",
+                    attempt,
+                    "recent context budget failure hint",
+                )
+                .await;
                 continue;
             }
             if should_skip_for_stream_silence_hint(&state, attempt, prompt_size_hint) {
+                crate::observability::record_skip(
+                    &state,
+                    &task_request_id,
+                    "chat",
+                    attempt,
+                    "recent stream silence hint",
+                )
+                .await;
                 continue;
             }
             if should_skip_for_rate_limit_hint(&state, attempt) {
+                crate::observability::record_skip(
+                    &state,
+                    &task_request_id,
+                    "chat",
+                    attempt,
+                    "recent rate limit hint",
+                )
+                .await;
                 continue;
             }
 
@@ -297,18 +382,46 @@ pub async fn create_chat_stream(
                         model = %model_id,
                         "Skipping streaming: circuit breaker open"
                     );
+                    crate::observability::record_skip(
+                        &state,
+                        &task_request_id,
+                        "chat",
+                        attempt,
+                        "circuit breaker open",
+                    )
+                    .await;
                     continue;
                 }
             }
 
             let adapter = match registry_clone.get(provider_id).await {
                 Some(a) => a,
-                None => continue,
+                None => {
+                    crate::observability::record_skip(
+                        &state,
+                        &task_request_id,
+                        "chat",
+                        attempt,
+                        "provider adapter missing from registry",
+                    )
+                    .await;
+                    continue;
+                }
             };
 
             let provider_cfg = match config_clone.providers.iter().find(|p| p.id == *provider_id) {
                 Some(c) => c.clone(),
-                None => continue,
+                None => {
+                    crate::observability::record_skip(
+                        &state,
+                        &task_request_id,
+                        "chat",
+                        attempt,
+                        "provider config missing",
+                    )
+                    .await;
+                    continue;
+                }
             };
 
             let ctx = ProviderContext {
@@ -338,6 +451,8 @@ pub async fn create_chat_stream(
                 timeout_ms = pre_content_timeout.as_millis(),
                 "Starting streaming attempt"
             );
+            crate::observability::record_attempt_started(&state, &task_request_id, "chat", attempt)
+                .await;
             let attempt_ctx = ctx.clone();
             let attempt_adapter = adapter.clone();
             let mut attempt_task = tokio::spawn(async move {
@@ -361,6 +476,16 @@ pub async fn create_chat_stream(
                                 model = %model_id,
                                 "Streaming completed"
                             );
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "stream_completed",
+                                None,
+                                None,
+                            )
+                            .await;
                             let _ = tx.send(StreamEvent::Done).await;
                             return;
                         }
@@ -372,6 +497,16 @@ pub async fn create_chat_stream(
                                         model = %model_id,
                                         "Streaming attempt completed without content; trying next planned attempt"
                                     );
+                                    crate::observability::record_attempt_result(
+                                        &state,
+                                        &task_request_id,
+                                        "chat",
+                                        attempt,
+                                        "empty_stream",
+                                        None,
+                                        Some("completed without content"),
+                                    )
+                                    .await;
                                 }
                                 Ok(Err(e)) => {
                                     warn!(
@@ -397,15 +532,35 @@ pub async fn create_chat_stream(
                                         );
                                     }
                                     record_streaming_provider_error(&state, provider_id, &e).await;
+                                    crate::observability::record_attempt_result(
+                                        &state,
+                                        &task_request_id,
+                                        "chat",
+                                        attempt,
+                                        "stream_failed_pre_content",
+                                        None,
+                                        Some(&e.to_string()),
+                                    )
+                                    .await;
                                 }
                                 Err(e) => {
                                     warn!(
                                         provider = %provider_id,
                                         model = %model_id,
                                         error = %e,
-                                        "Streaming attempt task failed before content; trying next planned attempt"
+                                    "Streaming attempt task failed before content; trying next planned attempt"
                                     );
                                     crate::resilience::health::record_failure(&state, provider_id).await;
+                                    crate::observability::record_attempt_result(
+                                        &state,
+                                        &task_request_id,
+                                        "chat",
+                                        attempt,
+                                        "stream_task_failed",
+                                        None,
+                                        Some(&e.to_string()),
+                                    )
+                                    .await;
                                 }
                             }
                         } else {
@@ -428,6 +583,16 @@ pub async fn create_chat_stream(
                                 model = %model_id,
                                 "Streaming completed"
                             );
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "stream_completed",
+                                None,
+                                None,
+                            )
+                            .await;
                             return;
                         }
                         continue;
@@ -451,6 +616,16 @@ pub async fn create_chat_stream(
                                 model_id,
                                 prompt_size_hint,
                             );
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "empty_stream",
+                                None,
+                                Some("ended without content"),
+                            )
+                            .await;
                             attempt_task.abort();
                             break;
                         } else {
@@ -465,6 +640,16 @@ pub async fn create_chat_stream(
                                 model = %model_id,
                                 "Streaming completed"
                             );
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "stream_completed",
+                                None,
+                                None,
+                            )
+                            .await;
                             let _ = tx.send(StreamEvent::Done).await;
                             return;
                         }
@@ -474,6 +659,16 @@ pub async fn create_chat_stream(
                                 model = %model_id,
                                 "Streaming attempt completed without content; trying next planned attempt"
                             );
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "empty_stream",
+                                None,
+                                Some("completed without content"),
+                            )
+                            .await;
                         }
                         Ok(Err(e)) => {
                             warn!(
@@ -499,15 +694,35 @@ pub async fn create_chat_stream(
                                 );
                             }
                             record_streaming_provider_error(&state, provider_id, &e).await;
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "stream_failed_pre_content",
+                                None,
+                                Some(&e.to_string()),
+                            )
+                            .await;
                         }
                         Err(e) => {
                             warn!(
                                 provider = %provider_id,
                                 model = %model_id,
                                 error = %e,
-                                "Streaming attempt task failed before content; trying next planned attempt"
+                            "Streaming attempt task failed before content; trying next planned attempt"
                             );
                             crate::resilience::health::record_failure(&state, provider_id).await;
+                            crate::observability::record_attempt_result(
+                                &state,
+                                &task_request_id,
+                                "chat",
+                                attempt,
+                                "stream_task_failed",
+                                None,
+                                Some(&e.to_string()),
+                            )
+                            .await;
                         }
                     }
                     break;
@@ -525,6 +740,16 @@ pub async fn create_chat_stream(
                             model_id,
                             prompt_size_hint,
                         );
+                        crate::observability::record_attempt_result(
+                            &state,
+                            &task_request_id,
+                            "chat",
+                            attempt,
+                            "stream_timeout_pre_content",
+                            Some(pre_content_timeout.as_millis() as i64),
+                            Some("timed out before content"),
+                        )
+                        .await;
                         attempt_task.abort();
                         break;
                     }
@@ -533,6 +758,34 @@ pub async fn create_chat_stream(
         }
 
         // All providers failed pre-stream or streaming failed
+        let _ = crate::usage::accounting::record_failure(
+            &state,
+            crate::usage::accounting::FailureRecord {
+                request_id: &task_request_id,
+                endpoint_kind: "chat",
+                requested_model: &request_clone.model,
+                selected_provider_id: plan.last().map(|attempt| attempt.provider_id.as_str()),
+                selected_model_id: plan.last().map(|attempt| attempt.model_id.as_str()),
+                status: "route_exhausted",
+                http_status: 503,
+                latency_ms: task_started_at.elapsed().as_millis() as i64,
+                streaming: true,
+            },
+        )
+        .await;
+        crate::observability::record_event(
+            &state,
+            crate::observability::TraceEventRecord {
+                request_id: &task_request_id,
+                event_type: "route_exhausted",
+                provider_id: plan.last().map(|attempt| attempt.provider_id.as_str()),
+                model_id: plan.last().map(|attempt| attempt.model_id.as_str()),
+                outcome: Some("route_exhausted"),
+                latency_ms: Some(task_started_at.elapsed().as_millis() as i64),
+                details: serde_json::json!({"endpoint_kind": "chat", "streaming": true}),
+            },
+        )
+        .await;
         let _ = tx.send(StreamEvent::Done).await;
     });
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -112,6 +112,7 @@ pub async fn ui_static(
         "routing" => crate::ui::routes::render_routing(&state).await,
         "usage" => crate::ui::routes::render_usage(&state).await,
         "health" => crate::ui::routes::render_health(&state).await,
+        "observability" => crate::ui::routes::render_observability(&state).await,
         "logs" => crate::ui::routes::render_logs(&state).await,
         "chat" => crate::ui::routes::render_chat(&state).await,
         "config" => crate::ui::routes::render_config(&state).await,
@@ -1062,6 +1063,7 @@ pub async fn admin_save_model_group(
 #[derive(serde::Deserialize)]
 pub struct AnalyticsQuery {
     pub period: Option<String>,
+    pub limit: Option<u32>,
 }
 
 pub async fn admin_analytics_traffic(
@@ -1101,6 +1103,60 @@ pub async fn admin_analytics_metrics(
     let period = query.period.unwrap_or_else(|| "24h".to_string());
     Ok(Json(
         crate::usage::aggregation::get_period_summary(&state, &period).await,
+    ))
+}
+
+pub async fn admin_observability_summary(
+    State(state): State<AppState>,
+    axum::extract::Query(query): axum::extract::Query<AnalyticsQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let period = query.period.unwrap_or_else(|| "24h".to_string());
+    Ok(Json(
+        crate::observability::get_observability_summary(&state, &period).await,
+    ))
+}
+
+pub async fn admin_request_traces(
+    State(state): State<AppState>,
+    axum::extract::Query(query): axum::extract::Query<AnalyticsQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    Ok(Json(
+        crate::observability::get_request_traces(
+            &state,
+            crate::observability::bounded_limit(query.limit),
+        )
+        .await,
+    ))
+}
+
+pub async fn admin_request_trace(
+    State(state): State<AppState>,
+    axum::extract::Path(request_id): axum::extract::Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    crate::observability::get_request_trace(&state, &request_id)
+        .await
+        .map(Json)
+        .ok_or_else(|| ApiError::InvalidRequest(format!("request trace '{request_id}' not found")))
+}
+
+pub async fn admin_incidents(
+    State(state): State<AppState>,
+    axum::extract::Query(query): axum::extract::Query<AnalyticsQuery>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    Ok(Json(
+        crate::observability::get_incidents(
+            &state,
+            crate::observability::bounded_limit(query.limit),
+        )
+        .await,
+    ))
+}
+
+pub async fn admin_diagnostic_bundle(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    Ok(Json(
+        crate::observability::get_diagnostic_bundle(&state).await,
     ))
 }
 

--- a/src/app/startup.rs
+++ b/src/app/startup.rs
@@ -430,6 +430,26 @@ pub fn build_router(state: AppState) -> Router {
             axum::routing::get(crate::api::routes::admin_analytics_metrics),
         )
         .route(
+            "/admin/observability/summary",
+            axum::routing::get(crate::api::routes::admin_observability_summary),
+        )
+        .route(
+            "/admin/request-traces",
+            axum::routing::get(crate::api::routes::admin_request_traces),
+        )
+        .route(
+            "/admin/request-traces/{request_id}",
+            axum::routing::get(crate::api::routes::admin_request_trace),
+        )
+        .route(
+            "/admin/incidents",
+            axum::routing::get(crate::api::routes::admin_incidents),
+        )
+        .route(
+            "/admin/diagnostics/bundle",
+            axum::routing::get(crate::api::routes::admin_diagnostic_bundle),
+        )
+        .route(
             "/admin/pricing",
             axum::routing::get(crate::api::routes::admin_pricing),
         )

--- a/src/db/migrations/20260621_000001_observability_incidents.sql
+++ b/src/db/migrations/20260621_000001_observability_incidents.sql
@@ -1,0 +1,17 @@
+-- Durable request traces for operator observability and incident diagnosis.
+CREATE TABLE IF NOT EXISTS request_trace_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT NOT NULL,
+    recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+    event_type TEXT NOT NULL,
+    provider_id TEXT,
+    model_id TEXT,
+    outcome TEXT,
+    latency_ms INTEGER,
+    details_json TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_request_trace_events_request ON request_trace_events(request_id, id);
+CREATE INDEX IF NOT EXISTS idx_request_trace_events_recorded ON request_trace_events(recorded_at);
+CREATE INDEX IF NOT EXISTS idx_request_trace_events_provider ON request_trace_events(provider_id);
+CREATE INDEX IF NOT EXISTS idx_request_trace_events_outcome ON request_trace_events(outcome);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod db;
 pub mod discovery;
 pub mod metrics;
+pub mod observability;
 pub mod providers;
 pub mod resilience;
 pub mod router;

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -23,10 +23,14 @@ fn interval_for_period(period: &str) -> &'static str {
 
 fn safe_details(value: serde_json::Value) -> String {
     let redacted = crate::util::redact::redact_json_value(value);
-    let mut text = serde_json::to_string(&redacted).unwrap_or_else(|_| "{}".to_string());
+    let text = serde_json::to_string(&redacted).unwrap_or_else(|_| "{}".to_string());
     if text.len() > 8192 {
-        text.truncate(8192);
-        text.push_str(r#","truncated":true}"#);
+        let preview = text.chars().take(8192).collect::<String>();
+        return serde_json::json!({
+            "truncated": true,
+            "preview": preview,
+        })
+        .to_string();
     }
     text
 }
@@ -484,7 +488,7 @@ pub async fn get_incidents(state: &AppState, limit: i64) -> serde_json::Value {
         "recorded_at": row.0,
         "provider_id": row.1,
         "title": format!("Provider {} {}", row.1, row.3),
-        "details": serde_json::from_str::<serde_json::Value>(row.4.as_deref().unwrap_or("{}")).unwrap_or_else(|_| json!({})),
+        "details": crate::util::redact::redact_json_value(serde_json::from_str::<serde_json::Value>(row.4.as_deref().unwrap_or("{}")).unwrap_or_else(|_| json!({}))),
     })));
     incidents.extend(audit.into_iter().map(|row| {
         json!({

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,0 +1,549 @@
+use crate::app::state::AppState;
+use crate::router::selection::RouteAttempt;
+use serde_json::json;
+
+const DEFAULT_LIMIT: i64 = 50;
+const MAX_LIMIT: i64 = 200;
+
+pub fn bounded_limit(limit: Option<u32>) -> i64 {
+    limit
+        .map(i64::from)
+        .unwrap_or(DEFAULT_LIMIT)
+        .clamp(1, MAX_LIMIT)
+}
+
+fn interval_for_period(period: &str) -> &'static str {
+    match period {
+        "7d" => "-7 days",
+        "30d" => "-30 days",
+        "1y" => "-1 year",
+        _ => "-24 hours",
+    }
+}
+
+fn safe_details(value: serde_json::Value) -> String {
+    let redacted = crate::util::redact::redact_json_value(value);
+    let mut text = serde_json::to_string(&redacted).unwrap_or_else(|_| "{}".to_string());
+    if text.len() > 8192 {
+        text.truncate(8192);
+        text.push_str(r#","truncated":true}"#);
+    }
+    text
+}
+
+fn short_error(error: &str) -> String {
+    let mut text = error.replace('\n', " ");
+    if text.len() > 512 {
+        text.truncate(512);
+        text.push_str("...");
+    }
+    text
+}
+
+pub struct TraceEventRecord<'a> {
+    pub request_id: &'a str,
+    pub event_type: &'a str,
+    pub provider_id: Option<&'a str>,
+    pub model_id: Option<&'a str>,
+    pub outcome: Option<&'a str>,
+    pub latency_ms: Option<i64>,
+    pub details: serde_json::Value,
+}
+
+pub async fn record_event(state: &AppState, event: TraceEventRecord<'_>) {
+    let _ = sqlx::query(
+        "INSERT INTO request_trace_events
+         (request_id, event_type, provider_id, model_id, outcome, latency_ms, details_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(event.request_id)
+    .bind(event.event_type)
+    .bind(event.provider_id)
+    .bind(event.model_id)
+    .bind(event.outcome)
+    .bind(event.latency_ms)
+    .bind(safe_details(event.details))
+    .execute(&state.db)
+    .await;
+}
+
+pub async fn record_route_plan(
+    state: &AppState,
+    request_id: &str,
+    endpoint_kind: &str,
+    requested_model: &str,
+    resolved_models: &[String],
+    plan: &[RouteAttempt],
+) {
+    let candidates = plan
+        .iter()
+        .map(|attempt| {
+            json!({
+                "provider_id": attempt.provider_id,
+                "model_id": attempt.model_id,
+                "priority": attempt.priority,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    record_event(
+        state,
+        TraceEventRecord {
+            request_id,
+            event_type: "route_plan",
+            provider_id: None,
+            model_id: None,
+            outcome: Some(if plan.is_empty() { "empty" } else { "planned" }),
+            latency_ms: None,
+            details: json!({
+            "endpoint_kind": endpoint_kind,
+            "requested_model": requested_model,
+            "resolved_models": resolved_models,
+            "candidate_count": candidates.len(),
+            "candidates": candidates,
+            }),
+        },
+    )
+    .await;
+}
+
+pub async fn record_attempt_started(
+    state: &AppState,
+    request_id: &str,
+    endpoint_kind: &str,
+    attempt: &RouteAttempt,
+) {
+    record_event(
+        state,
+        TraceEventRecord {
+            request_id,
+            event_type: "attempt_started",
+            provider_id: Some(&attempt.provider_id),
+            model_id: Some(&attempt.model_id),
+            outcome: Some("started"),
+            latency_ms: None,
+            details: json!({
+                "endpoint_kind": endpoint_kind,
+                "priority": attempt.priority,
+            }),
+        },
+    )
+    .await;
+}
+
+pub async fn record_attempt_result(
+    state: &AppState,
+    request_id: &str,
+    endpoint_kind: &str,
+    attempt: &RouteAttempt,
+    outcome: &str,
+    latency_ms: Option<i64>,
+    error_summary: Option<&str>,
+) {
+    record_event(
+        state,
+        TraceEventRecord {
+            request_id,
+            event_type: "attempt_result",
+            provider_id: Some(&attempt.provider_id),
+            model_id: Some(&attempt.model_id),
+            outcome: Some(outcome),
+            latency_ms,
+            details: json!({
+                "endpoint_kind": endpoint_kind,
+                "priority": attempt.priority,
+                "error_summary": error_summary.map(short_error),
+            }),
+        },
+    )
+    .await;
+}
+
+pub async fn record_skip(
+    state: &AppState,
+    request_id: &str,
+    endpoint_kind: &str,
+    attempt: &RouteAttempt,
+    reason: &str,
+) {
+    record_event(
+        state,
+        TraceEventRecord {
+            request_id,
+            event_type: "attempt_skipped",
+            provider_id: Some(&attempt.provider_id),
+            model_id: Some(&attempt.model_id),
+            outcome: Some("skipped"),
+            latency_ms: None,
+            details: json!({
+                "endpoint_kind": endpoint_kind,
+                "priority": attempt.priority,
+                "reason": reason,
+            }),
+        },
+    )
+    .await;
+}
+
+pub async fn get_request_traces(state: &AppState, limit: i64) -> serde_json::Value {
+    let rows = sqlx::query_as::<
+        _,
+        (
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            String,
+            Option<i64>,
+            i64,
+            i64,
+            f64,
+        ),
+    >(
+        "SELECT
+            r.request_id,
+            r.received_at,
+            r.endpoint_kind,
+            r.requested_model,
+            r.selected_provider_id,
+            r.status,
+            r.http_status,
+            COALESCE(r.latency_ms, 0),
+            COALESCE(r.fallback_count, 0),
+            COALESCE(SUM(u.estimated_cost_usd), 0.0)
+         FROM request_log r
+         LEFT JOIN usage_events u ON u.request_id = r.request_id
+         GROUP BY r.request_id
+         ORDER BY r.received_at DESC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    json!({
+        "traces": rows.into_iter().map(|row| json!({
+            "request_id": row.0,
+            "received_at": row.1,
+            "endpoint_kind": row.2,
+            "requested_model": row.3,
+            "selected_provider_id": row.4,
+            "status": row.5,
+            "http_status": row.6,
+            "latency_ms": row.7,
+            "fallback_count": row.8,
+            "estimated_cost_usd": row.9,
+        })).collect::<Vec<_>>()
+    })
+}
+
+pub async fn get_request_trace(state: &AppState, request_id: &str) -> Option<serde_json::Value> {
+    let request = sqlx::query_as::<
+        _,
+        (
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            String,
+            Option<i64>,
+            Option<i64>,
+            bool,
+            i64,
+            i64,
+            Option<String>,
+            Option<String>,
+        ),
+    >(
+        "SELECT request_id, received_at, endpoint_kind, requested_model, resolved_model_group,
+                selected_provider_id, status, http_status, latency_ms, streaming, retry_count,
+                fallback_count, error_code, error_summary
+         FROM request_log
+         WHERE request_id = ?",
+    )
+    .bind(request_id)
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten()?;
+
+    let usage = sqlx::query_as::<_, (String, Option<String>, i64, i64, f64, String, bool, String)>(
+        "SELECT provider_id, model_id, input_tokens, output_tokens, estimated_cost_usd,
+                cost_confidence, free_tier, timestamp
+         FROM usage_events
+         WHERE request_id = ?
+         ORDER BY id ASC",
+    )
+    .bind(request_id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let events = sqlx::query_as::<
+        _,
+        (
+            i64,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<i64>,
+            String,
+        ),
+    >(
+        "SELECT id, recorded_at, event_type, provider_id, model_id, outcome, latency_ms, details_json
+         FROM request_trace_events
+         WHERE request_id = ?
+         ORDER BY id ASC",
+    )
+    .bind(request_id)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let event_values = events
+        .into_iter()
+        .map(|event| {
+            let details =
+                serde_json::from_str::<serde_json::Value>(&event.7).unwrap_or_else(|_| json!({}));
+            json!({
+                "id": event.0,
+                "recorded_at": event.1,
+                "event_type": event.2,
+                "provider_id": event.3,
+                "model_id": event.4,
+                "outcome": event.5,
+                "latency_ms": event.6,
+                "details": details,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let usage_values = usage
+        .into_iter()
+        .map(|row| {
+            json!({
+                "provider_id": row.0,
+                "model_id": row.1,
+                "input_tokens": row.2,
+                "output_tokens": row.3,
+                "estimated_cost_usd": row.4,
+                "cost_confidence": row.5,
+                "free_tier": row.6,
+                "timestamp": row.7,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Some(json!({
+        "request": {
+            "request_id": request.0,
+            "received_at": request.1,
+            "endpoint_kind": request.2,
+            "requested_model": request.3,
+            "resolved_model_group": request.4,
+            "selected_provider_id": request.5,
+            "status": request.6,
+            "http_status": request.7,
+            "latency_ms": request.8,
+            "streaming": request.9,
+            "retry_count": request.10,
+            "fallback_count": request.11,
+            "error_code": request.12,
+            "error_summary": request.13,
+        },
+        "usage": usage_values,
+        "events": event_values,
+    }))
+}
+
+pub async fn get_observability_summary(state: &AppState, period: &str) -> serde_json::Value {
+    let interval = interval_for_period(period);
+    let requests = sqlx::query_as::<_, (i64, i64, i64, i64, i64, i64)>(&format!(
+        "SELECT
+                COUNT(*),
+                COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN http_status = 429 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(fallback_count), 0),
+                COALESCE(CAST(AVG(latency_ms) AS INTEGER), 0),
+                COALESCE(SUM(CASE WHEN status != 'success' THEN 1 ELSE 0 END), 0)
+             FROM request_log
+             WHERE received_at > datetime('now', '{}')",
+        interval
+    ))
+    .fetch_one(&state.db)
+    .await
+    .unwrap_or((0, 0, 0, 0, 0, 0));
+
+    let usage = sqlx::query_as::<_, (i64, i64, f64)>(&format!(
+        "SELECT
+                COALESCE(SUM(input_tokens), 0),
+                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(estimated_cost_usd), 0.0)
+             FROM usage_events
+             WHERE timestamp > datetime('now', '{}')",
+        interval
+    ))
+    .fetch_one(&state.db)
+    .await
+    .unwrap_or((0, 0, 0.0));
+
+    let saturation = sqlx::query_as::<_, (String, i64, i64, i64)>(&format!(
+        "SELECT
+                selected_provider_id,
+                COUNT(*),
+                COALESCE(SUM(CASE WHEN http_status = 429 THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status != 'success' THEN 1 ELSE 0 END), 0)
+             FROM request_log
+             WHERE selected_provider_id IS NOT NULL
+               AND received_at > datetime('now', '{}')
+             GROUP BY selected_provider_id
+             ORDER BY COUNT(*) DESC
+             LIMIT 20",
+        interval
+    ))
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let total = requests.0.max(0) as f64;
+    json!({
+        "period": period,
+        "request_count": requests.0,
+        "success_count": requests.1,
+        "failure_count": requests.5,
+        "success_rate": if total > 0.0 { requests.1 as f64 / total } else { 0.0 },
+        "rate_limit_count": requests.2,
+        "rate_limit_rate": if total > 0.0 { requests.2 as f64 / total } else { 0.0 },
+        "fallback_count": requests.3,
+        "avg_latency_ms": requests.4,
+        "input_tokens": usage.0,
+        "output_tokens": usage.1,
+        "total_tokens": usage.0 + usage.1,
+        "estimated_cost_usd": usage.2,
+        "provider_saturation": saturation.into_iter().map(|row| json!({
+            "provider_id": row.0,
+            "request_count": row.1,
+            "rate_limit_count": row.2,
+            "failure_count": row.3,
+            "rate_limit_rate": if row.1 > 0 { row.2 as f64 / row.1 as f64 } else { 0.0 },
+            "failure_rate": if row.1 > 0 { row.3 as f64 / row.1 as f64 } else { 0.0 },
+        })).collect::<Vec<_>>()
+    })
+}
+
+pub async fn get_incidents(state: &AppState, limit: i64) -> serde_json::Value {
+    let health = sqlx::query_as::<_, (String, String, String, String, Option<String>)>(
+        "SELECT recorded_at, provider_id, health_state, event_type, details_json
+         FROM provider_health_events
+         WHERE event_type LIKE '%failure%'
+            OR event_type LIKE '%timeout%'
+            OR health_state IN ('degraded', 'rate_limited', 'quota_exhausted', 'unhealthy')
+            OR breaker_state IN ('open', 'half_open')
+         ORDER BY recorded_at DESC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let audit = sqlx::query_as::<_, (String, String, Option<String>, Option<String>)>(
+        "SELECT created_at, action, target_type, target_id
+         FROM config_audit_log
+         ORDER BY created_at DESC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(&state.db)
+    .await
+    .unwrap_or_default();
+
+    let failures =
+        sqlx::query_as::<_, (String, Option<String>, Option<String>, String, Option<i64>)>(
+            "SELECT received_at, selected_provider_id, selected_model_id, status, http_status
+         FROM request_log
+         WHERE status != 'success'
+         ORDER BY received_at DESC
+         LIMIT ?",
+        )
+        .bind(limit)
+        .fetch_all(&state.db)
+        .await
+        .unwrap_or_default();
+
+    let mut incidents = Vec::new();
+    incidents.extend(health.into_iter().map(|row| json!({
+        "kind": "provider_health",
+        "severity": if row.2 == "unhealthy" { "critical" } else { "warning" },
+        "recorded_at": row.0,
+        "provider_id": row.1,
+        "title": format!("Provider {} {}", row.1, row.3),
+        "details": serde_json::from_str::<serde_json::Value>(row.4.as_deref().unwrap_or("{}")).unwrap_or_else(|_| json!({})),
+    })));
+    incidents.extend(audit.into_iter().map(|row| {
+        json!({
+            "kind": "config_change",
+            "severity": if row.1.contains("rejected") { "warning" } else { "info" },
+            "recorded_at": row.0,
+            "title": row.1,
+            "target_type": row.2,
+            "target_id": row.3,
+        })
+    }));
+    incidents.extend(failures.into_iter().map(|row| {
+        json!({
+            "kind": "request_failure",
+            "severity": if row.4 == Some(429) { "warning" } else { "critical" },
+            "recorded_at": row.0,
+            "provider_id": row.1,
+            "model_id": row.2,
+            "title": row.3,
+            "http_status": row.4,
+        })
+    }));
+
+    incidents.sort_by(|left, right| {
+        right
+            .get("recorded_at")
+            .and_then(|value| value.as_str())
+            .cmp(&left.get("recorded_at").and_then(|value| value.as_str()))
+    });
+    incidents.truncate(limit as usize);
+
+    json!({ "incidents": incidents })
+}
+
+pub async fn get_diagnostic_bundle(state: &AppState) -> serde_json::Value {
+    let config = serde_json::to_value(&*state.config()).unwrap_or_else(|_| json!({}));
+    let health_states = state
+        .health_states
+        .iter()
+        .map(|entry| {
+            json!({
+                "provider_id": entry.key(),
+                "state": format!("{:?}", entry.value().state),
+                "recent_successes": entry.value().recent_successes,
+                "recent_failures": entry.value().recent_failures,
+                "last_success_at": entry.value().last_success_at,
+                "last_error_at": entry.value().last_error_at,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "generated_at": chrono::Utc::now().to_rfc3339(),
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_secs": state.start_time.elapsed().as_secs(),
+        "config": crate::util::redact::redact_json_value(config),
+        "observability_summary_24h": get_observability_summary(state, "24h").await,
+        "recent_request_traces": get_request_traces(state, 25).await["traces"].clone(),
+        "recent_incidents": get_incidents(state, 25).await["incidents"].clone(),
+        "health_states": health_states,
+    })
+}

--- a/src/router/engine.rs
+++ b/src/router/engine.rs
@@ -77,6 +77,15 @@ pub async fn route_chat_request(
     assign_attempt_priorities(&mut plan);
 
     if plan.is_empty() {
+        crate::observability::record_route_plan(
+            &state,
+            &request_id,
+            "chat",
+            &request.model,
+            &resolved_models,
+            &plan,
+        )
+        .await;
         record_route_failure(
             &state,
             RouteFailure {
@@ -121,6 +130,15 @@ pub async fn route_chat_request(
     .await;
 
     if plan.is_empty() {
+        crate::observability::record_route_plan(
+            &state,
+            &request_id,
+            "chat",
+            &request.model,
+            &resolved_models,
+            &plan,
+        )
+        .await;
         record_route_failure(
             &state,
             RouteFailure {
@@ -149,16 +167,42 @@ pub async fn route_chat_request(
         plan = ?plan.iter().map(|p| p.label()).collect::<Vec<_>>(),
         "Route plan built"
     );
+    crate::observability::record_route_plan(
+        &state,
+        &request_id,
+        "chat",
+        &request.model,
+        &resolved_models,
+        &plan,
+    )
+    .await;
 
     // Execute the plan: try providers in order
     let mut last_error = None;
     let prompt_size_hint = request.prompt_size_hint();
     for attempt in &plan {
+        let attempt_started_at = std::time::Instant::now();
         let provider_id = &attempt.provider_id;
         if should_skip_for_context_hint(&state, attempt, prompt_size_hint) {
+            crate::observability::record_skip(
+                &state,
+                &request_id,
+                "chat",
+                attempt,
+                "recent context budget failure hint",
+            )
+            .await;
             continue;
         }
         if should_skip_for_rate_limit_hint(&state, attempt) {
+            crate::observability::record_skip(
+                &state,
+                &request_id,
+                "chat",
+                attempt,
+                "recent rate limit hint",
+            )
+            .await;
             continue;
         }
 
@@ -166,6 +210,14 @@ pub async fn route_chat_request(
         if let Some(breaker) = state.breaker_states.get(provider_id) {
             if breaker.is_open() {
                 info!(provider = %provider_id, "Skipping: circuit breaker open");
+                crate::observability::record_skip(
+                    &state,
+                    &request_id,
+                    "chat",
+                    attempt,
+                    "circuit breaker open",
+                )
+                .await;
                 continue;
             }
         }
@@ -175,6 +227,14 @@ pub async fn route_chat_request(
             Some(a) => a,
             None => {
                 warn!(provider = %provider_id, "Provider not found in registry");
+                crate::observability::record_skip(
+                    &state,
+                    &request_id,
+                    "chat",
+                    attempt,
+                    "provider adapter missing from registry",
+                )
+                .await;
                 continue;
             }
         };
@@ -182,10 +242,26 @@ pub async fn route_chat_request(
         let capabilities = adapter.capabilities();
         if request.tools.is_some() && !capabilities.supports_tools {
             info!(provider = %provider_id, "Skipping: tools not supported");
+            crate::observability::record_skip(
+                &state,
+                &request_id,
+                "chat",
+                attempt,
+                "tools not supported",
+            )
+            .await;
             continue;
         }
         if request.response_format.is_some() && !capabilities.supports_json_mode {
             info!(provider = %provider_id, "Skipping: response_format/json mode not supported");
+            crate::observability::record_skip(
+                &state,
+                &request_id,
+                "chat",
+                attempt,
+                "json mode not supported",
+            )
+            .await;
             continue;
         }
 
@@ -206,6 +282,7 @@ pub async fn route_chat_request(
         };
 
         // Attempt the request
+        crate::observability::record_attempt_started(&state, &request_id, "chat", attempt).await;
         match adapter
             .chat_completions(
                 &ctx,
@@ -222,6 +299,16 @@ pub async fn route_chat_request(
                     latency_ms = response.latency_ms,
                     "Chat completion succeeded"
                 );
+                crate::observability::record_attempt_result(
+                    &state,
+                    &request_id,
+                    "chat",
+                    attempt,
+                    "success",
+                    Some(response.latency_ms),
+                    None,
+                )
+                .await;
 
                 // Record usage and metrics
                 let usage_ref = response.usage.as_ref().map(provider_usage_to_openai_usage);
@@ -261,6 +348,16 @@ pub async fn route_chat_request(
             }
             Err(e) => {
                 warn!(provider = %provider_id, error = %e, "Provider attempt failed");
+                crate::observability::record_attempt_result(
+                    &state,
+                    &request_id,
+                    "chat",
+                    attempt,
+                    failure_status_for_error(Some(&e)),
+                    Some(attempt_started_at.elapsed().as_millis() as i64),
+                    Some(&e.to_string()),
+                )
+                .await;
 
                 // Record provider-health failures only for errors that indicate
                 // provider instability rather than request-specific capacity.
@@ -289,6 +386,23 @@ pub async fn route_chat_request(
                         let mut retries = 0;
                         while retries < max_attempts {
                             warn!(provider = %provider_id, retry = retries + 1, "Retrying same provider");
+                            crate::observability::record_event(
+                                &state,
+                                crate::observability::TraceEventRecord {
+                                    request_id: &request_id,
+                                    event_type: "attempt_retry",
+                                    provider_id: Some(provider_id),
+                                    model_id: Some(&attempt.model_id),
+                                    outcome: Some("retrying"),
+                                    latency_ms: None,
+                                    details: serde_json::json!({
+                                        "endpoint_kind": "chat",
+                                        "retry": retries + 1,
+                                        "max_attempts": max_attempts,
+                                    }),
+                                },
+                            )
+                            .await;
                             match adapter
                                 .chat_completions(
                                     &ctx,
@@ -301,6 +415,16 @@ pub async fn route_chat_request(
                             {
                                 Ok(response) => {
                                     info!(provider = %provider_id, "Retry succeeded");
+                                    crate::observability::record_attempt_result(
+                                        &state,
+                                        &request_id,
+                                        "chat",
+                                        attempt,
+                                        "success_after_retry",
+                                        Some(response.latency_ms),
+                                        None,
+                                    )
+                                    .await;
                                     let usage_ref =
                                         response.usage.as_ref().map(provider_usage_to_openai_usage);
                                     let _ = crate::usage::accounting::record_usage(
@@ -341,6 +465,16 @@ pub async fn route_chat_request(
                                 }
                                 Err(e2) => {
                                     warn!(provider = %provider_id, error = %e2, "Retry failed");
+                                    crate::observability::record_attempt_result(
+                                        &state,
+                                        &request_id,
+                                        "chat",
+                                        attempt,
+                                        failure_status_for_error(Some(&e2)),
+                                        None,
+                                        Some(&e2.to_string()),
+                                    )
+                                    .await;
                                     if let ProviderError::RateLimited { retry_after, .. } = &e2 {
                                         record_rate_limit_hint(
                                             &state,
@@ -356,6 +490,22 @@ pub async fn route_chat_request(
                         }
                     }
                     FallbackDecision::RetryWithDelay { delay_ms } => {
+                        crate::observability::record_event(
+                            &state,
+                            crate::observability::TraceEventRecord {
+                                request_id: &request_id,
+                                event_type: "attempt_retry_delay",
+                                provider_id: Some(provider_id),
+                                model_id: Some(&attempt.model_id),
+                                outcome: Some("delayed_retry"),
+                                latency_ms: None,
+                                details: serde_json::json!({
+                                    "endpoint_kind": "chat",
+                                    "delay_ms": delay_ms,
+                                }),
+                            },
+                        )
+                        .await;
                         tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                         match adapter
                             .chat_completions(
@@ -369,6 +519,16 @@ pub async fn route_chat_request(
                         {
                             Ok(response) => {
                                 info!(provider = %provider_id, "Retry after delay succeeded");
+                                crate::observability::record_attempt_result(
+                                    &state,
+                                    &request_id,
+                                    "chat",
+                                    attempt,
+                                    "success_after_delay",
+                                    Some(response.latency_ms),
+                                    None,
+                                )
+                                .await;
                                 let usage_ref =
                                     response.usage.as_ref().map(provider_usage_to_openai_usage);
                                 let _ = crate::usage::accounting::record_usage(
@@ -408,6 +568,16 @@ pub async fn route_chat_request(
                                 });
                             }
                             Err(e2) => {
+                                crate::observability::record_attempt_result(
+                                    &state,
+                                    &request_id,
+                                    "chat",
+                                    attempt,
+                                    failure_status_for_error(Some(&e2)),
+                                    None,
+                                    Some(&e2.to_string()),
+                                )
+                                .await;
                                 if let ProviderError::RateLimited { retry_after, .. } = &e2 {
                                     record_rate_limit_hint(
                                         &state,
@@ -421,7 +591,21 @@ pub async fn route_chat_request(
                             }
                         }
                     }
-                    FallbackDecision::TryNextProvider => { /* continue to next provider */ }
+                    FallbackDecision::TryNextProvider => {
+                        crate::observability::record_event(
+                            &state,
+                            crate::observability::TraceEventRecord {
+                                request_id: &request_id,
+                                event_type: "fallback_decision",
+                                provider_id: Some(provider_id),
+                                model_id: Some(&attempt.model_id),
+                                outcome: Some("try_next_provider"),
+                                latency_ms: None,
+                                details: serde_json::json!({"endpoint_kind": "chat"}),
+                            },
+                        )
+                        .await;
+                    }
                     FallbackDecision::Fail => {
                         record_route_failure(
                             &state,
@@ -508,6 +692,15 @@ pub async fn route_embeddings_request(
     assign_attempt_priorities(&mut plan);
 
     if plan.is_empty() {
+        crate::observability::record_route_plan(
+            &state,
+            &request_id,
+            "embeddings",
+            &request.model,
+            &resolved_models,
+            &plan,
+        )
+        .await;
         record_route_failure(
             &state,
             RouteFailure {
@@ -545,6 +738,15 @@ pub async fn route_embeddings_request(
     )
     .await;
     if plan.is_empty() {
+        crate::observability::record_route_plan(
+            &state,
+            &request_id,
+            "embeddings",
+            &request.model,
+            &resolved_models,
+            &plan,
+        )
+        .await;
         record_route_failure(
             &state,
             RouteFailure {
@@ -562,21 +764,57 @@ pub async fn route_embeddings_request(
         .await;
     }
     let mut last_error = None;
+    crate::observability::record_route_plan(
+        &state,
+        &request_id,
+        "embeddings",
+        &request.model,
+        &resolved_models,
+        &plan,
+    )
+    .await;
     for attempt in &plan {
+        let attempt_started_at = std::time::Instant::now();
         let provider_id = &attempt.provider_id;
 
         if let Some(breaker) = state.breaker_states.get(provider_id) {
             if breaker.is_open() {
+                crate::observability::record_skip(
+                    &state,
+                    &request_id,
+                    "embeddings",
+                    attempt,
+                    "circuit breaker open",
+                )
+                .await;
                 continue;
             }
         }
 
         let adapter = match registry.get(provider_id).await {
             Some(a) => a,
-            None => continue,
+            None => {
+                crate::observability::record_skip(
+                    &state,
+                    &request_id,
+                    "embeddings",
+                    attempt,
+                    "provider adapter missing from registry",
+                )
+                .await;
+                continue;
+            }
         };
 
         if !adapter.supports_endpoint(&EndpointKind::Embeddings) {
+            crate::observability::record_skip(
+                &state,
+                &request_id,
+                "embeddings",
+                attempt,
+                "embeddings not supported",
+            )
+            .await;
             continue;
         }
 
@@ -595,6 +833,8 @@ pub async fn route_embeddings_request(
             client: state.http_client.clone(),
         };
 
+        crate::observability::record_attempt_started(&state, &request_id, "embeddings", attempt)
+            .await;
         match adapter
             .embeddings(
                 &ctx,
@@ -606,6 +846,16 @@ pub async fn route_embeddings_request(
             .await
         {
             Ok(response) => {
+                crate::observability::record_attempt_result(
+                    &state,
+                    &request_id,
+                    "embeddings",
+                    attempt,
+                    "success",
+                    Some(response.latency_ms),
+                    None,
+                )
+                .await;
                 let usage = crate::api::openai::chat::UsageResponse {
                     prompt_tokens: response.usage.prompt_tokens,
                     completion_tokens: response.usage.completion_tokens,
@@ -637,6 +887,16 @@ pub async fn route_embeddings_request(
                 });
             }
             Err(e) => {
+                crate::observability::record_attempt_result(
+                    &state,
+                    &request_id,
+                    "embeddings",
+                    attempt,
+                    failure_status_for_error(Some(&e)),
+                    Some(attempt_started_at.elapsed().as_millis() as i64),
+                    Some(&e.to_string()),
+                )
+                .await;
                 last_error = Some(e);
                 if let Some(error) = last_error.as_ref() {
                     if crate::resilience::health::should_record_provider_failure(error) {

--- a/src/ui/routes.rs
+++ b/src/ui/routes.rs
@@ -1309,7 +1309,7 @@ pub async fn render_observability(state: &AppState) -> String {
                         "text-red-400"
                     };
                     format!(
-                        r#"<tr><td class="font-mono text-xs text-cyan-400">{}</td><td class="font-mono text-xs">{}</td><td>{}</td><td>{}</td><td class="{} font-bold text-xs uppercase">{}</td><td class="font-mono">{}ms</td><td><button class="btn text-xs" onclick="loadTrace('{}')">Open</button></td></tr>"#,
+                        r#"<tr><td class="font-mono text-xs text-cyan-400">{}</td><td class="font-mono text-xs">{}</td><td>{}</td><td>{}</td><td class="{} font-bold text-xs uppercase">{}</td><td class="font-mono">{}ms</td><td><button class="btn text-xs" data-request-id="{}" onclick="loadTraceFromButton(this)">Open</button></td></tr>"#,
                         request_id, model, provider, trace["endpoint_kind"], status_class, status, latency, request_id
                     )
                 })
@@ -1457,7 +1457,7 @@ pub async fn render_observability(state: &AppState) -> String {
         const status = trace.status || 'unknown';
         const cls = status === 'success' ? 'text-emerald-400' : (trace.http_status === 429 ? 'text-yellow-400' : 'text-red-400');
         const id = htmlEscape(trace.request_id);
-        return `<tr><td class="font-mono text-xs text-cyan-400">${id}</td><td class="font-mono text-xs">${htmlEscape(trace.requested_model)}</td><td>${htmlEscape(trace.selected_provider_id || '-')}</td><td>${htmlEscape(trace.endpoint_kind)}</td><td class="${cls} font-bold text-xs uppercase">${htmlEscape(status)}</td><td class="font-mono">${trace.latency_ms || 0}ms</td><td><button class="btn text-xs" onclick="loadTrace('${id}')">Open</button></td></tr>`;
+        return `<tr><td class="font-mono text-xs text-cyan-400">${id}</td><td class="font-mono text-xs">${htmlEscape(trace.requested_model)}</td><td>${htmlEscape(trace.selected_provider_id || '-')}</td><td>${htmlEscape(trace.endpoint_kind)}</td><td class="${cls} font-bold text-xs uppercase">${htmlEscape(status)}</td><td class="font-mono">${trace.latency_ms || 0}ms</td><td><button class="btn text-xs" data-request-id="${id}" onclick="loadTraceFromButton(this)">Open</button></td></tr>`;
     }
     function incidentRow(incident) {
         const severity = incident.severity || 'info';
@@ -1485,6 +1485,9 @@ pub async fn render_observability(state: &AppState) -> String {
         const detail = await response.json();
         document.getElementById('trace-title').innerText = requestId;
         document.getElementById('trace-detail').innerText = JSON.stringify(detail, null, 2);
+    }
+    function loadTraceFromButton(button) {
+        loadTrace(button.dataset.requestId || '');
     }
     async function downloadDiagnosticBundle() {
         const bundle = await fetch('/admin/diagnostics/bundle').then(r => r.json());

--- a/src/ui/routes.rs
+++ b/src/ui/routes.rs
@@ -98,6 +98,7 @@ pub fn render_shell(
         {}
         {}
         {}
+        {}
         </nav>"#,
         nav_item("dashboard", "/ui", "fas fa-th-large", "Dashboard"),
         nav_item("providers", "/ui/providers", "fas fa-server", "Providers"),
@@ -105,6 +106,12 @@ pub fn render_shell(
         nav_item("routing", "/ui/routing", "fas fa-route", "Routing"),
         nav_item("usage", "/ui/usage", "fas fa-chart-line", "Usage"),
         nav_item("chat", "/ui/chat", "fas fa-comment-dots", "Chat Tester"),
+        nav_item(
+            "observability",
+            "/ui/observability",
+            "fas fa-wave-square",
+            "Observability"
+        ),
         nav_item("health", "/ui/health", "fas fa-heartbeat", "Health"),
         nav_item("logs", "/ui/logs", "fas fa-terminal", "Logs"),
         nav_item("config", "/ui/config", "fas fa-cog", "Config"),
@@ -1250,6 +1257,248 @@ pub async fn render_health(state: &AppState) -> String {
         rows
     );
     render_shell("Health", "health", &content, "", state)
+}
+
+/// Render the observability and incident workflow view.
+pub async fn render_observability(state: &AppState) -> String {
+    let summary = crate::observability::get_observability_summary(state, "24h").await;
+    let traces = crate::observability::get_request_traces(state, 20).await;
+    let incidents = crate::observability::get_incidents(state, 20).await;
+
+    let trace_rows = traces
+        .get("traces")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .map(|trace| {
+                    let request_id = escape_html(
+                        trace
+                            .get("request_id")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("?"),
+                    );
+                    let status = escape_html(
+                        trace
+                            .get("status")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("unknown"),
+                    );
+                    let model = escape_html(
+                        trace
+                            .get("requested_model")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("?"),
+                    );
+                    let provider = escape_html(
+                        trace
+                            .get("selected_provider_id")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("-"),
+                    );
+                    let latency = trace
+                        .get("latency_ms")
+                        .and_then(|value| value.as_i64())
+                        .unwrap_or(0);
+                    let status_class = if status == "success" {
+                        "text-emerald-400"
+                    } else if trace.get("http_status").and_then(|value| value.as_i64()) == Some(429)
+                    {
+                        "text-yellow-400"
+                    } else {
+                        "text-red-400"
+                    };
+                    format!(
+                        r#"<tr><td class="font-mono text-xs text-cyan-400">{}</td><td class="font-mono text-xs">{}</td><td>{}</td><td>{}</td><td class="{} font-bold text-xs uppercase">{}</td><td class="font-mono">{}ms</td><td><button class="btn text-xs" onclick="loadTrace('{}')">Open</button></td></tr>"#,
+                        request_id, model, provider, trace["endpoint_kind"], status_class, status, latency, request_id
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .filter(|rows| !rows.is_empty())
+        .unwrap_or_else(|| {
+            r#"<tr><td colspan="7" class="px-6 py-4 text-center text-slate-500">No request traces yet</td></tr>"#
+                .to_string()
+        });
+
+    let incident_rows = incidents
+        .get("incidents")
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .map(|incident| {
+                    let severity = incident
+                        .get("severity")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("info");
+                    let severity_class = match severity {
+                        "critical" => "text-red-400 bg-red-500/10",
+                        "warning" => "text-yellow-400 bg-yellow-500/10",
+                        _ => "text-cyan-300 bg-cyan-500/10",
+                    };
+                    let title = escape_html(
+                        incident
+                            .get("title")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("incident"),
+                    );
+                    let kind = escape_html(
+                        incident
+                            .get("kind")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("event"),
+                    );
+                    let recorded_at = escape_html(
+                        incident
+                            .get("recorded_at")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("-"),
+                    );
+                    format!(
+                        r#"<tr><td class="font-mono text-xs">{}</td><td><span class="px-2 py-0.5 rounded text-[10px] uppercase {}">{}</span></td><td class="text-xs text-slate-400">{}</td><td class="font-bold">{}</td></tr>"#,
+                        recorded_at, severity_class, severity, kind, title
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .filter(|rows| !rows.is_empty())
+        .unwrap_or_else(|| {
+            r#"<tr><td colspan="4" class="px-6 py-4 text-center text-slate-500">No incidents recorded</td></tr>"#
+                .to_string()
+        });
+
+    let request_count = summary
+        .get("request_count")
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0);
+    let success_rate = summary
+        .get("success_rate")
+        .and_then(|value| value.as_f64())
+        .unwrap_or(0.0)
+        * 100.0;
+    let rate_limit_rate = summary
+        .get("rate_limit_rate")
+        .and_then(|value| value.as_f64())
+        .unwrap_or(0.0)
+        * 100.0;
+    let fallback_count = summary
+        .get("fallback_count")
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0);
+    let total_tokens = summary
+        .get("total_tokens")
+        .and_then(|value| value.as_i64())
+        .unwrap_or(0);
+    let estimated_cost = summary
+        .get("estimated_cost_usd")
+        .and_then(|value| value.as_f64())
+        .unwrap_or(0.0);
+
+    let content = format!(
+        r#"
+        <div class="flex items-center justify-between gap-4 mb-2">
+            <div class="text-xs font-bold text-slate-500 uppercase tracking-widest">Incident Console</div>
+            <div class="flex gap-2">
+                <select id="observability-period" class="bg-white/5 border border-white/10 rounded px-3 py-2 text-sm" onchange="refreshObservability()">
+                    <option value="24h">24H</option>
+                    <option value="7d">7D</option>
+                    <option value="30d">30D</option>
+                </select>
+                <button class="btn" onclick="downloadDiagnosticBundle()">Export Bundle</button>
+            </div>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
+            <div class="glass-card p-5"><div class="text-xs font-bold text-slate-500 uppercase">Requests</div><div id="obs-requests" class="text-3xl font-bold mt-2">{}</div></div>
+            <div class="glass-card p-5"><div class="text-xs font-bold text-slate-500 uppercase">Success</div><div id="obs-success" class="text-3xl font-bold mt-2 text-emerald-400">{:.1}%</div></div>
+            <div class="glass-card p-5"><div class="text-xs font-bold text-slate-500 uppercase">429 Rate</div><div id="obs-rate-limit" class="text-3xl font-bold mt-2 text-yellow-400">{:.1}%</div></div>
+            <div class="glass-card p-5"><div class="text-xs font-bold text-slate-500 uppercase">Fallbacks</div><div id="obs-fallbacks" class="text-3xl font-bold mt-2">{}</div></div>
+            <div class="glass-card p-5"><div class="text-xs font-bold text-slate-500 uppercase">Tokens</div><div id="obs-tokens" class="text-3xl font-bold mt-2">{}</div></div>
+            <div class="glass-card p-5"><div class="text-xs font-bold text-slate-500 uppercase">Cost</div><div id="obs-cost" class="text-3xl font-bold mt-2">{}</div></div>
+        </div>
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <div class="glass-card overflow-hidden">
+                <div class="px-6 py-4 border-b border-white/5 bg-white/[0.02]"><h3 class="font-bold">Request Traces</h3></div>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-left"><thead class="text-slate-500 border-b border-white/5 bg-white/[0.01]"><tr><th>Request</th><th>Model</th><th>Provider</th><th>Endpoint</th><th>Status</th><th>Latency</th><th>Trace</th></tr></thead><tbody id="trace-rows" class="divide-y divide-white/5">{}</tbody></table>
+                </div>
+            </div>
+            <div class="glass-card overflow-hidden">
+                <div class="px-6 py-4 border-b border-white/5 bg-white/[0.02]"><h3 class="font-bold">Incident Feed</h3></div>
+                <div class="overflow-x-auto">
+                    <table class="w-full text-left"><thead class="text-slate-500 border-b border-white/5 bg-white/[0.01]"><tr><th>Time</th><th>Severity</th><th>Kind</th><th>Event</th></tr></thead><tbody id="incident-rows" class="divide-y divide-white/5">{}</tbody></table>
+                </div>
+            </div>
+        </div>
+        <div class="glass-card overflow-hidden">
+            <div class="px-6 py-4 border-b border-white/5 bg-white/[0.02] flex items-center justify-between"><h3 class="font-bold">Trace Timeline</h3><span id="trace-title" class="font-mono text-xs text-slate-500">Select a request</span></div>
+            <pre id="trace-detail" class="p-4 bg-[#010409] font-mono text-[11px] leading-relaxed overflow-x-auto text-slate-300 min-h-[220px]"></pre>
+        </div>"#,
+        format_number(request_count),
+        success_rate,
+        rate_limit_rate,
+        format_number(fallback_count),
+        format_number(total_tokens),
+        format_currency(estimated_cost),
+        trace_rows,
+        incident_rows
+    );
+
+    let scripts = r#"<script>
+    function htmlEscape(value) {
+        return String(value ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    }
+    function money(value) {
+        return new Intl.NumberFormat('en-US', {style:'currency', currency:'USD', minimumFractionDigits:2, maximumFractionDigits:4}).format(Number(value || 0));
+    }
+    function traceRow(trace) {
+        const status = trace.status || 'unknown';
+        const cls = status === 'success' ? 'text-emerald-400' : (trace.http_status === 429 ? 'text-yellow-400' : 'text-red-400');
+        const id = htmlEscape(trace.request_id);
+        return `<tr><td class="font-mono text-xs text-cyan-400">${id}</td><td class="font-mono text-xs">${htmlEscape(trace.requested_model)}</td><td>${htmlEscape(trace.selected_provider_id || '-')}</td><td>${htmlEscape(trace.endpoint_kind)}</td><td class="${cls} font-bold text-xs uppercase">${htmlEscape(status)}</td><td class="font-mono">${trace.latency_ms || 0}ms</td><td><button class="btn text-xs" onclick="loadTrace('${id}')">Open</button></td></tr>`;
+    }
+    function incidentRow(incident) {
+        const severity = incident.severity || 'info';
+        const cls = severity === 'critical' ? 'text-red-400 bg-red-500/10' : (severity === 'warning' ? 'text-yellow-400 bg-yellow-500/10' : 'text-cyan-300 bg-cyan-500/10');
+        return `<tr><td class="font-mono text-xs">${htmlEscape(incident.recorded_at || '-')}</td><td><span class="px-2 py-0.5 rounded text-[10px] uppercase ${cls}">${htmlEscape(severity)}</span></td><td class="text-xs text-slate-400">${htmlEscape(incident.kind)}</td><td class="font-bold">${htmlEscape(incident.title)}</td></tr>`;
+    }
+    async function refreshObservability() {
+        const period = document.getElementById('observability-period').value;
+        const [summary, traces, incidents] = await Promise.all([
+            fetch(`/admin/observability/summary?period=${period}`).then(r => r.json()),
+            fetch('/admin/request-traces?limit=20').then(r => r.json()),
+            fetch('/admin/incidents?limit=20').then(r => r.json())
+        ]);
+        document.getElementById('obs-requests').innerText = Number(summary.request_count || 0).toLocaleString();
+        document.getElementById('obs-success').innerText = ((summary.success_rate || 0) * 100).toFixed(1) + '%';
+        document.getElementById('obs-rate-limit').innerText = ((summary.rate_limit_rate || 0) * 100).toFixed(1) + '%';
+        document.getElementById('obs-fallbacks').innerText = Number(summary.fallback_count || 0).toLocaleString();
+        document.getElementById('obs-tokens').innerText = Number(summary.total_tokens || 0).toLocaleString();
+        document.getElementById('obs-cost').innerText = money(summary.estimated_cost_usd);
+        document.getElementById('trace-rows').innerHTML = (traces.traces || []).map(traceRow).join('') || '<tr><td colspan="7" class="px-6 py-4 text-center text-slate-500">No request traces yet</td></tr>';
+        document.getElementById('incident-rows').innerHTML = (incidents.incidents || []).map(incidentRow).join('') || '<tr><td colspan="4" class="px-6 py-4 text-center text-slate-500">No incidents recorded</td></tr>';
+    }
+    async function loadTrace(requestId) {
+        const response = await fetch('/admin/request-traces/' + encodeURIComponent(requestId));
+        const detail = await response.json();
+        document.getElementById('trace-title').innerText = requestId;
+        document.getElementById('trace-detail').innerText = JSON.stringify(detail, null, 2);
+    }
+    async function downloadDiagnosticBundle() {
+        const bundle = await fetch('/admin/diagnostics/bundle').then(r => r.json());
+        const blob = new Blob([JSON.stringify(bundle, null, 2)], {type:'application/json'});
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `tokenscavenger-diagnostics-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+    setInterval(refreshObservability, 30000);
+    </script>"#;
+    render_shell("Observability", "observability", &content, scripts, state)
 }
 
 /// Render the logs view.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -913,6 +913,182 @@ async fn test_route_plan_endpoint_explains_attempts() {
 }
 
 #[tokio::test]
+async fn test_observability_endpoints_return_traces_incidents_and_redacted_bundle() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let mut config = Config::default();
+    config.providers = vec![tokenscavenger::config::schema::ProviderConfig {
+        id: "local".into(),
+        enabled: true,
+        base_url: Some("http://127.0.0.1:11434/v1".into()),
+        api_key: Some("sk-secret-observability-key".into()),
+        free_only: true,
+        discover_models: false,
+        embedding_support: Default::default(),
+    }];
+    let state = AppState::new(
+        config,
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    );
+
+    sqlx::query(
+        "INSERT INTO request_log
+         (request_id, endpoint_kind, requested_model, selected_provider_id, selected_model_id, status, http_status, latency_ms, fallback_count)
+         VALUES ('req-ok', 'chat', 'fast:chat', 'local', 'llama3.2', 'success', 200, 42, 1)",
+    )
+    .execute(&state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO usage_events
+         (request_id, provider_id, model_id, input_tokens, output_tokens, estimated_cost_usd, cost_confidence, free_tier)
+         VALUES ('req-ok', 'local', 'llama3.2', 12, 8, 0.0, 'free_tier', 1)",
+    )
+    .execute(&state.db)
+    .await
+    .unwrap();
+    tokenscavenger::observability::record_event(
+        &state,
+        tokenscavenger::observability::TraceEventRecord {
+            request_id: "req-ok",
+            event_type: "route_plan",
+            provider_id: None,
+            model_id: None,
+            outcome: Some("planned"),
+            latency_ms: None,
+            details: json!({"api_key": "sk-never-return-this", "candidate_count": 1}),
+        },
+    )
+    .await;
+    sqlx::query(
+        "INSERT INTO request_log
+         (request_id, endpoint_kind, requested_model, selected_provider_id, selected_model_id, status, http_status, latency_ms)
+         VALUES ('req-429', 'chat', 'fast:chat', 'local', 'llama3.2', 'rate_limited', 429, 13)",
+    )
+    .execute(&state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO provider_health_events (provider_id, health_state, breaker_state, event_type, details_json)
+         VALUES ('local', 'unhealthy', 'open', 'passive_failure', '{\"reason\":\"boom\"}')",
+    )
+    .execute(&state.db)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO config_audit_log (actor, action, target_type) VALUES ('operator', 'config_update', 'config')",
+    )
+    .execute(&state.db)
+    .await
+    .unwrap();
+
+    let router = tokenscavenger::app::startup::build_router(state);
+
+    let summary_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/observability/summary?period=24h")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(summary_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(summary_response.into_body(), 65536)
+        .await
+        .unwrap();
+    let summary: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(summary["request_count"], 2);
+    assert_eq!(summary["rate_limit_count"], 1);
+    assert_eq!(summary["fallback_count"], 1);
+    assert_eq!(summary["total_tokens"], 20);
+
+    let traces_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/request-traces?limit=10")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(traces_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(traces_response.into_body(), 65536)
+        .await
+        .unwrap();
+    let traces: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(traces["traces"].as_array().unwrap().len() >= 2);
+
+    let trace_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/request-traces/req-ok")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(trace_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(trace_response.into_body(), 65536)
+        .await
+        .unwrap();
+    let trace: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(trace["request"]["request_id"], "req-ok");
+    assert_eq!(trace["usage"][0]["input_tokens"], 12);
+    assert_eq!(trace["events"][0]["details"]["api_key"], "****this");
+
+    let incidents_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/incidents?limit=10")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(incidents_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(incidents_response.into_body(), 65536)
+        .await
+        .unwrap();
+    let incidents: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        incidents["incidents"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|incident| {
+                incident["kind"] == "provider_health" || incident["kind"] == "request_failure"
+            })
+    );
+
+    let bundle_response = router
+        .oneshot(
+            Request::builder()
+                .uri("/admin/diagnostics/bundle")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(bundle_response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(bundle_response.into_body(), 262144)
+        .await
+        .unwrap();
+    let bundle_text = String::from_utf8(body.to_vec()).unwrap();
+    assert!(!bundle_text.contains("sk-secret-observability-key"));
+    assert!(bundle_text.contains("****-key"));
+}
+
+#[tokio::test]
 async fn test_config_save_creates_snapshot_and_rollback_restores_it() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     sqlx::migrate!("src/db/migrations")

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -33,6 +33,7 @@ async fn test_clean_bootstrap() {
         "provider_health_events",
         "providers",
         "request_log",
+        "request_trace_events",
         "usage_events",
         "_sqlx_migrations",
     ];
@@ -129,6 +130,19 @@ async fn test_can_insert_and_query_all_tables() {
 
     sqlx::query("INSERT INTO provider_health_events (provider_id, health_state, event_type) VALUES (?, ?, ?)")
         .bind("test").bind("healthy").bind("test").execute(&pool).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO request_trace_events (request_id, event_type, provider_id, model_id, outcome)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind("req-1")
+    .bind("attempt_result")
+    .bind("test")
+    .bind("m1")
+    .bind("success")
+    .execute(&pool)
+    .await
+    .unwrap();
 
     sqlx::query("INSERT INTO discovery_runs (provider_id, status) VALUES (?, ?)")
         .bind("test")


### PR DESCRIPTION
## Summary

- Add durable request trace events with route plans, skips, attempts, retries, fallback decisions, and streaming pre-content exhaustion accounting.
- Add observability admin APIs for time-window summary, request traces, incident feed, and redacted diagnostic bundles.
- Add `/ui/observability`, Grafana dashboard and Prometheus alert starter assets, docs, changelog, and roadmap tidy-up.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `pnpm --dir docs build`
- `git diff --check`
- Local smoke on `127.0.0.1:18991` for `/admin/observability/summary`, `/admin/request-traces`, `/admin/incidents`, `/admin/diagnostics/bundle`, and `/ui/observability`

## Notes

- `.dev/` remains ignored and was not staged or committed.
- Diagnostic bundles and trace details redact secrets and do not persist full request/response bodies.