### PR TITLE
Add role-aware external admin identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added role-aware admin authorization with read-only, operator, config editor,
+  credential manager, and admin roles.
+- Added external identity support for the admin UI/API through trusted
+  reverse-proxy headers, enabling Google, GitHub, Microsoft, and OSS OIDC
+  providers through proxies such as oauth2-proxy, Dex, Authelia, Keycloak, and
+  Zitadel.
+- Added `GET /admin/whoami` for validating the authenticated admin principal,
+  auth source, resolved role, and credential-management permission.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
 - **Circuit breakers, retries & health monitoring**
 - **Prometheus metrics**, request traces, incident feed, and diagnostic bundles
 - **Embedded web UI** with live dashboard, observability, logs, and config editor
+- **Team-ready admin auth** with role-aware access and external identity headers
+  from OIDC-capable reverse proxies
 - **SQLite persistence** (WAL mode) for usage accounting and audit log
 - **Interactive setup wizard** and CLI tools
 - **Single static binary** (~15–25 MB)
@@ -300,6 +302,11 @@ See [ROADMAP.md](ROADMAP.md) for five high-value future enhancements that can pu
 ## Deployment
 
 See [documentation/deployment.md](documentation/deployment.md) for deployment options including Docker, systemd, and cross-compilation.
+
+For team deployments, TokenScavenger can trust identity headers from an
+OIDC-capable reverse proxy such as oauth2-proxy, Dex, Authelia, Keycloak, Zitadel,
+or a cloud identity proxy. Groups map to read-only, operator, config editor,
+credential manager, and admin roles for the operator UI and admin API.
 
 ## Operator UI
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,19 +68,21 @@ This roadmap is intentionally focused on five high-value enhancements. Each one 
 
 ## 5. Deployment, Security, And Team Controls
 
+**Status:** In progress. Role-aware admin access and external identity integration are implemented for v0.3.4.
+
 **Current baseline:** The project already documents static binary builds, Docker, Docker Compose, systemd, reverse proxy deployment, Prometheus scraping, health checks, SQLite backup, and upgrade steps in `documentation/deployment.md`. It also supports bearer auth, CORS controls, query-key opt-in, session-cookie UI auth, secret redaction, and release artifacts with checksums.
 
 **Why it matters:** To be an enterprise self-hosted gateway, TokenScavenger should deepen security and team workflows without becoming a managed platform or weakening the single-binary deployment path.
 
 **What good looks like:**
 
-- Role-aware admin access for read-only operators, config editors, and credential managers.
+- [x] Role-aware admin access for read-only operators, config editors, and credential managers.
 - Optional encrypted provider credential storage using OS keychains or an operator-supplied encryption key.
 - Cryptographically signed release artifacts, SBOM generation, and documented verification steps beyond the existing checksum release flow.
 - Self-update support that alerts admins when a new TokenScavenger release is available, offers an admin UI CTA to apply it, installs the new version safely, and reloads the app/UI onto the updated binary by restarting with the same executable arguments and configuration used for the current process.
 - Homebrew packaging and Kubernetes manifests that complement the existing binary, Docker, Docker Compose, and systemd deployment docs.
 - Restore drills, retention policy controls, and migration rollback guidance for SQLite state, extending the current backup and automatic migration docs.
-- Optional external identity integration for the admin UI, such as OIDC reverse-proxy headers, while keeping local auth simple.
+- [x] Optional external identity integration for the admin UI, such as OIDC reverse-proxy headers, while keeping local auth simple.
 
 ## How To Contribute
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,38 +5,38 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="title"
-      content="TokenScavenger v0.3.3 | Observable LLM Routing"
+      content="TokenScavenger v0.3.4 | Team-Ready LLM Routing"
     />
     <meta
       name="description"
-      content="TokenScavenger v0.3.3 adds request traces, incident workflow, redacted diagnostic bundles, and Grafana/Prometheus starters to local-first LLM routing."
+      content="TokenScavenger v0.3.4 adds role-aware admin access and external identity headers for team-operated local-first LLM routing."
     />
     <meta name="robots" content="index, follow" />
     <link rel="icon" type="image/png" href="assets/TokenScavengerLogo.png" />
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="TokenScavenger v0.3.3 | Observable LLM Routing"
+      content="TokenScavenger v0.3.4 | Team-Ready LLM Routing"
     />
     <meta
       property="og:description"
-      content="Route local, free-tier, and explicit paid fallback models through one self-hosted gateway with request traces and incident diagnostics."
+      content="Route local, free-tier, and explicit paid fallback models through one self-hosted gateway with role-aware admin access."
     />
     <meta
       property="og:image"
       content="/assets/token-scavenger-v0.3.0-local-release.png"
     />
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:title" content="TokenScavenger v0.3.3" />
+    <meta property="twitter:title" content="TokenScavenger v0.3.4" />
     <meta
       property="twitter:description"
-      content="Now with request traces, incident workflow, redacted diagnostic bundles, and Grafana/Prometheus starters."
+      content="Now with role-aware admin access and external identity headers for OIDC-capable reverse proxies."
     />
     <meta
       property="twitter:image"
       content="/assets/token-scavenger-v0.3.0-local-release.png"
     />
-    <title>TokenScavenger v0.3.3 | Observable LLM Routing</title>
+    <title>TokenScavenger v0.3.4 | Team-Ready LLM Routing</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -178,9 +178,9 @@
               gateway.
             </h1>
             <p class="mt-6 max-w-xl text-lg leading-8 text-slate-300">
-              TokenScavenger v0.3.3 routes local, free-tier, and explicit paid
-              fallback providers with durable request traces, incident
-              diagnostics, and redacted support bundles.
+              TokenScavenger v0.3.4 routes local, free-tier, and explicit paid
+              fallback providers with role-aware admin access, external
+              identity headers, and durable incident diagnostics.
             </p>
             <div class="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
               <a
@@ -349,7 +349,7 @@
               </p>
               <pre
                 class="mt-6 min-w-0 overflow-x-auto rounded-2xl bg-slate-950/80 p-5 text-sm leading-6 text-slate-200"
-              ><code>VERSION=v0.3.3
+              ><code>VERSION=v0.3.4
 curl -LO https://github.com/kabudu/token-scavenger/releases/download/$VERSION/tokenscavenger-$VERSION-aarch64-apple-darwin.zip
 unzip tokenscavenger-$VERSION-aarch64-apple-darwin.zip
 ./tokenscavenger</code></pre>
@@ -369,7 +369,7 @@ unzip tokenscavenger-$VERSION-aarch64-apple-darwin.zip
               </p>
               <pre
                 class="mt-6 min-w-0 overflow-x-auto rounded-2xl bg-slate-950/80 p-5 text-sm leading-6 text-slate-200"
-              ><code>VERSION=v0.3.3
+              ><code>VERSION=v0.3.4
 curl -LO https://github.com/kabudu/token-scavenger/releases/download/$VERSION/tokenscavenger-$VERSION-x86_64-unknown-linux-gnu
 chmod +x tokenscavenger-$VERSION-x86_64-unknown-linux-gnu
 ./tokenscavenger-$VERSION-x86_64-unknown-linux-gnu</code></pre>
@@ -389,7 +389,7 @@ chmod +x tokenscavenger-$VERSION-x86_64-unknown-linux-gnu
               </p>
               <pre
                 class="mt-6 min-w-0 max-w-full whitespace-pre-wrap break-all rounded-2xl bg-slate-950/80 p-5 text-sm leading-6 text-slate-200"
-              ><code class="whitespace-pre-wrap break-all">$Version = "v0.3.3"
+              ><code class="whitespace-pre-wrap break-all">$Version = "v0.3.4"
 $Url = "https://github.com/kabudu/token-scavenger/releases/download/$Version/tokenscavenger-$Version-x86_64-pc-windows-msvc.exe"
 Invoke-WebRequest `
   -Uri $Url `

--- a/documentation/api-behavior.md
+++ b/documentation/api-behavior.md
@@ -18,6 +18,7 @@ TokenScavenger exposes OpenAI-compatible HTTP endpoints while routing each reque
 | `GET /admin/request-traces/{request_id}` | Detailed route timeline, usage, and request outcome for one request. |
 | `GET /admin/incidents` | Incident feed derived from provider health events, route failures, and config audit history. |
 | `GET /admin/diagnostics/bundle` | Redacted diagnostic bundle for support and incident handoff. |
+| `GET /admin/whoami` | Current authenticated admin principal, auth source, role, and credential-management permission. |
 
 ## Error Shape
 
@@ -148,3 +149,20 @@ Authorization: Bearer <master-api-key>
 ```
 
 The key is for TokenScavenger itself. Provider API keys remain in TokenScavenger configuration and are never returned in API responses, logs, fixtures, or UI payloads.
+
+For admin UI/API access, TokenScavenger can also trust identity headers from an
+identity-aware reverse proxy when `[server.external_identity] enabled = true`.
+This supports Google, GitHub, Microsoft, and OSS identity providers through
+OIDC-capable proxies such as oauth2-proxy, Dex, Authelia, Keycloak, and Zitadel.
+
+External identity headers authorize only `/ui` and `/admin/*`. They do not
+authorize OpenAI-compatible client endpoints under `/v1/*`; those continue to
+use the `master_api_key` when configured.
+
+Role enforcement:
+
+- `read_only`: view UI and read admin APIs.
+- `operator`: read-only plus operational POSTs such as provider tests and discovery refreshes.
+- `config_editor`: mutate non-secret runtime config.
+- `credential_manager`: update credential-bearing config fields such as provider API keys.
+- `admin`: full admin access.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -15,6 +15,19 @@ ui_enabled = true                   # Enable/disable operator dashboard
 ui_path = "/ui"                     # URL prefix for UI
 request_timeout_ms = 120000         # Upstream request timeout
 
+[server.external_identity]
+enabled = false                     # Trust identity headers from a reverse proxy
+user_header = "x-auth-request-user"
+email_header = "x-auth-request-email"
+name_header = "x-auth-request-preferred-username"
+groups_header = "x-auth-request-groups"
+group_delimiter = ","
+read_only_groups = []
+operator_groups = []
+config_editor_groups = []
+credential_manager_groups = []
+admin_groups = []
+
 [database]
 path = "tokenscavenger.db"          # SQLite database file path
 max_connections = 8                 # SQLite pool size
@@ -88,6 +101,44 @@ target = ["groq/llama3-70b-8192", "google/gemini-2.0-flash"]
 | `ui_enabled` | `true` | Whether to serve the operator web UI |
 | `ui_path` | `"/ui"` | URL path prefix for the UI |
 | `request_timeout_ms` | `120000` | Maximum time to wait for an upstream provider response |
+
+#### `[server.external_identity]`
+
+External identity support lets TokenScavenger sit behind an identity-aware
+reverse proxy such as oauth2-proxy, Dex, Authelia, Keycloak, Zitadel, or a cloud
+load balancer. Those systems can authenticate Google, GitHub, Microsoft, or any
+OIDC/SAML provider and forward trusted identity headers to TokenScavenger.
+
+TokenScavenger does not trust these headers unless `enabled = true`. When
+enabled, external identity headers authorize only `/ui` and `/admin/*`; OpenAI
+client endpoints such as `/v1/chat/completions` still require the
+`master_api_key` when one is configured.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enables trusted reverse-proxy identity headers for admin UI/API access. |
+| `user_header` | `"x-auth-request-user"` | Header containing the stable subject/user id. |
+| `email_header` | `"x-auth-request-email"` | Optional email header used for display and audit actor strings. |
+| `name_header` | `"x-auth-request-preferred-username"` | Optional display-name header. |
+| `groups_header` | `"x-auth-request-groups"` | Header containing group names. |
+| `group_delimiter` | `","` | Delimiter used to split the groups header. |
+| `read_only_groups` | `[]` | Groups allowed to view the UI and read admin APIs. |
+| `operator_groups` | `[]` | Groups allowed to run operational actions such as provider tests and discovery refreshes. |
+| `config_editor_groups` | `[]` | Groups allowed to edit non-secret runtime configuration. |
+| `credential_manager_groups` | `[]` | Groups allowed to update credential-bearing fields such as provider API keys. |
+| `admin_groups` | `[]` | Groups with full admin access. |
+
+Example:
+
+```toml
+[server.external_identity]
+enabled = true
+read_only_groups = ["tokenscavenger-viewers"]
+operator_groups = ["tokenscavenger-operators"]
+config_editor_groups = ["tokenscavenger-editors"]
+credential_manager_groups = ["tokenscavenger-credential-managers"]
+admin_groups = ["tokenscavenger-admins"]
+```
 
 ### `[database]`
 

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -140,6 +140,38 @@ allowed_cors_origins = ["https://proxy.example.com"]
 allow_query_api_keys = false     # Prefer Authorization: Bearer <key>
 ```
 
+### External Identity
+
+For teams, put TokenScavenger behind an identity-aware reverse proxy and map
+provider groups into TokenScavenger roles. This keeps Google, GitHub, Microsoft,
+and other OIDC providers outside the runtime while allowing the admin UI/API to
+enforce local permissions.
+
+```toml
+[server]
+bind = "127.0.0.1:8000"
+master_api_key = "${PROXY_KEY}"
+
+[server.external_identity]
+enabled = true
+read_only_groups = ["tokenscavenger-viewers"]
+operator_groups = ["tokenscavenger-operators"]
+config_editor_groups = ["tokenscavenger-editors"]
+credential_manager_groups = ["tokenscavenger-credential-managers"]
+admin_groups = ["tokenscavenger-admins"]
+```
+
+The reverse proxy must strip any incoming identity headers from clients before
+setting its own trusted values. TokenScavenger expects these default headers:
+
+- `x-auth-request-user`
+- `x-auth-request-email`
+- `x-auth-request-preferred-username`
+- `x-auth-request-groups`
+
+Use `GET /admin/whoami` after deployment to verify the resolved identity source,
+subject, role, and credential-management permission.
+
 ### Reverse Proxy (Nginx)
 
 ```nginx
@@ -156,6 +188,10 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Host $host;
+        proxy_set_header X-Auth-Request-User $upstream_http_x_auth_request_user;
+        proxy_set_header X-Auth-Request-Email $upstream_http_x_auth_request_email;
+        proxy_set_header X-Auth-Request-Preferred-Username $upstream_http_x_auth_request_preferred_username;
+        proxy_set_header X-Auth-Request-Groups $upstream_http_x_auth_request_groups;
         proxy_read_timeout 300s;
         proxy_buffering off;  # Required for streaming
     }

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,12 +1,73 @@
 use crate::app::state::AppState;
+use crate::config::schema::ExternalIdentityConfig;
 use axum::{
     body::Body,
     extract::State,
-    http::{Request, StatusCode, header},
+    http::{HeaderMap, Method, Request, StatusCode, header},
     middleware::Next,
     response::{IntoResponse, Response},
 };
 use tracing::warn;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AdminRole {
+    ReadOnly,
+    Operator,
+    ConfigEditor,
+    CredentialManager,
+    Admin,
+}
+
+impl AdminRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AdminRole::ReadOnly => "read_only",
+            AdminRole::Operator => "operator",
+            AdminRole::ConfigEditor => "config_editor",
+            AdminRole::CredentialManager => "credential_manager",
+            AdminRole::Admin => "admin",
+        }
+    }
+
+    pub fn can_manage_credentials(self) -> bool {
+        matches!(self, AdminRole::CredentialManager | AdminRole::Admin)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthContext {
+    pub subject: String,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub role: AdminRole,
+    pub source: AuthSource,
+}
+
+impl AuthContext {
+    pub fn audit_actor(&self) -> String {
+        match &self.email {
+            Some(email) if !email.is_empty() => format!("{}:{}", self.source.as_str(), email),
+            _ => format!("{}:{}", self.source.as_str(), self.subject),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AuthSource {
+    MasterKey,
+    UiSession,
+    ExternalIdentity,
+}
+
+impl AuthSource {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AuthSource::MasterKey => "master_key",
+            AuthSource::UiSession => "ui_session",
+            AuthSource::ExternalIdentity => "external_identity",
+        }
+    }
+}
 
 /// Optional API key authentication middleware.
 /// If `server.master_api_key` is set, all requests must include
@@ -22,8 +83,14 @@ pub async fn auth_middleware(
     let method = req.method().clone();
     let path = req.uri().path().to_string();
 
-    if master_key.is_empty() {
-        // Auth disabled
+    if master_key.is_empty() && !config.server.external_identity.enabled {
+        // Auth disabled.
+        return Ok(next.run(req).await);
+    }
+
+    let required_role = required_admin_role(&method, &path);
+
+    if master_key.is_empty() && config.server.external_identity.enabled && required_role.is_none() {
         return Ok(next.run(req).await);
     }
 
@@ -37,7 +104,19 @@ pub async fn auth_middleware(
 
     if let Some(token) = auth_header.strip_prefix("Bearer ") {
         if token == master_key {
-            return Ok(next.run(req).await);
+            return run_authorized(
+                req,
+                next,
+                AuthContext {
+                    subject: "master".into(),
+                    email: None,
+                    display_name: Some("Master key".into()),
+                    role: AdminRole::Admin,
+                    source: AuthSource::MasterKey,
+                },
+                required_role,
+            )
+            .await;
         }
     }
 
@@ -51,9 +130,29 @@ pub async fn auth_middleware(
             });
             if let Some(token) = session {
                 if state.ui_sessions.contains_key(token) {
-                    return Ok(next.run(req).await);
+                    return run_authorized(
+                        req,
+                        next,
+                        AuthContext {
+                            subject: "browser-session".into(),
+                            email: None,
+                            display_name: Some("Browser session".into()),
+                            role: AdminRole::Admin,
+                            source: AuthSource::UiSession,
+                        },
+                        required_role,
+                    )
+                    .await;
                 }
             }
+        }
+    }
+
+    if config.server.external_identity.enabled && is_admin_or_ui_request(&path) {
+        if let Some(context) =
+            external_identity_context(req.headers(), &config.server.external_identity)
+        {
+            return run_authorized(req, next, context, required_role).await;
         }
     }
 
@@ -69,7 +168,19 @@ pub async fn auth_middleware(
             })
         }) {
             if query_key == master_key {
-                return Ok(next.run(req).await);
+                return run_authorized(
+                    req,
+                    next,
+                    AuthContext {
+                        subject: "master".into(),
+                        email: None,
+                        display_name: Some("Master key".into()),
+                        role: AdminRole::Admin,
+                        source: AuthSource::MasterKey,
+                    },
+                    required_role,
+                )
+                .await;
             }
         }
     }
@@ -87,6 +198,112 @@ pub async fn auth_middleware(
     Err(StatusCode::UNAUTHORIZED)
 }
 
+async fn run_authorized(
+    mut req: Request<Body>,
+    next: Next,
+    context: AuthContext,
+    required_role: Option<AdminRole>,
+) -> Result<Response, StatusCode> {
+    if let Some(required) = required_role {
+        if context.role < required {
+            warn!(
+                subject = %context.subject,
+                role = %context.role.as_str(),
+                required_role = %required.as_str(),
+                "Authorization failed: insufficient admin role"
+            );
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
+    req.extensions_mut().insert(context);
+    Ok(next.run(req).await)
+}
+
 fn is_ui_request(path: &str) -> bool {
     path == "/ui" || path.starts_with("/ui/")
+}
+
+fn is_admin_or_ui_request(path: &str) -> bool {
+    is_ui_request(path) || path.starts_with("/admin/")
+}
+
+fn required_admin_role(method: &Method, path: &str) -> Option<AdminRole> {
+    if is_ui_request(path) {
+        return Some(AdminRole::ReadOnly);
+    }
+    if !path.starts_with("/admin/") {
+        return None;
+    }
+    if method == Method::GET {
+        return Some(AdminRole::ReadOnly);
+    }
+    if method == Method::POST && path.ends_with("/test") {
+        return Some(AdminRole::Operator);
+    }
+    if method == Method::POST && path == "/admin/providers/discovery/refresh" {
+        return Some(AdminRole::Operator);
+    }
+    Some(AdminRole::ConfigEditor)
+}
+
+fn external_identity_context(
+    headers: &HeaderMap,
+    config: &ExternalIdentityConfig,
+) -> Option<AuthContext> {
+    let subject = header_value(headers, &config.user_header)
+        .or_else(|| header_value(headers, &config.email_header))?;
+    let email = header_value(headers, &config.email_header);
+    let display_name = header_value(headers, &config.name_header);
+    let groups = header_value(headers, &config.groups_header)
+        .map(|raw| split_groups(&raw, &config.group_delimiter))
+        .unwrap_or_default();
+    let role = role_from_groups(&groups, config)?;
+
+    Some(AuthContext {
+        subject,
+        email,
+        display_name,
+        role,
+        source: AuthSource::ExternalIdentity,
+    })
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn split_groups(raw: &str, delimiter: &str) -> Vec<String> {
+    let delimiter = if delimiter.is_empty() { "," } else { delimiter };
+    raw.split(delimiter)
+        .map(str::trim)
+        .filter(|group| !group.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn role_from_groups(groups: &[String], config: &ExternalIdentityConfig) -> Option<AdminRole> {
+    if matches_any(groups, &config.admin_groups) {
+        Some(AdminRole::Admin)
+    } else if matches_any(groups, &config.credential_manager_groups) {
+        Some(AdminRole::CredentialManager)
+    } else if matches_any(groups, &config.config_editor_groups) {
+        Some(AdminRole::ConfigEditor)
+    } else if matches_any(groups, &config.operator_groups) {
+        Some(AdminRole::Operator)
+    } else if matches_any(groups, &config.read_only_groups) {
+        Some(AdminRole::ReadOnly)
+    } else {
+        None
+    }
+}
+
+fn matches_any(groups: &[String], allowed: &[String]) -> bool {
+    groups
+        .iter()
+        .any(|group| allowed.iter().any(|allowed| group == allowed))
 }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -27,6 +27,8 @@ pub enum ApiError {
     InvalidRequest(String),
     #[error("Authentication failed")]
     AuthError,
+    #[error("Forbidden")]
+    Forbidden,
     #[error("Provider unavailable: {0}")]
     ProviderUnavailable(String),
     #[error("All routes exhausted: {0}")]
@@ -58,6 +60,12 @@ impl IntoResponse for ApiError {
                 "auth_error".into(),
                 "authentication_error".into(),
                 "Authentication failed".into(),
+            ),
+            ApiError::Forbidden => (
+                StatusCode::FORBIDDEN,
+                "forbidden".into(),
+                "permission_error".into(),
+                "Permission denied".into(),
             ),
             ApiError::ProviderUnavailable(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2,6 +2,7 @@ use crate::api::error::ApiError;
 use crate::app::state::AppState;
 use axum::response::sse::Event;
 use axum::{
+    Extension,
     extract::{Query, State},
     http::{HeaderMap, HeaderValue, header},
     response::{Html, IntoResponse, Json, Sse},
@@ -150,6 +151,32 @@ pub async fn admin_providers(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let providers = crate::providers::registry::get_providers_state(&state).await;
     Ok(Json(providers))
+}
+
+pub async fn admin_whoami(
+    auth: Option<Extension<crate::api::auth::AuthContext>>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Some(Extension(context)) = auth else {
+        return Ok(Json(serde_json::json!({
+            "authenticated": true,
+            "source": "disabled",
+            "role": "admin"
+        })));
+    };
+
+    Ok(Json(serde_json::json!({
+        "authenticated": true,
+        "source": match context.source {
+            crate::api::auth::AuthSource::MasterKey => "master_key",
+            crate::api::auth::AuthSource::UiSession => "ui_session",
+            crate::api::auth::AuthSource::ExternalIdentity => "external_identity",
+        },
+        "subject": context.subject,
+        "email": context.email,
+        "display_name": context.display_name,
+        "role": context.role.as_str(),
+        "can_manage_credentials": context.role.can_manage_credentials()
+    })))
 }
 
 pub async fn admin_session(
@@ -517,8 +544,19 @@ pub async fn admin_provider_test(
 /// PUT /admin/config — save operator config changes (hot-reloads without restart)
 pub async fn admin_config_save(
     State(state): State<AppState>,
+    auth: Option<Extension<crate::api::auth::AuthContext>>,
     axum::Json(body): axum::Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    let auth_context = auth.map(|Extension(context)| context);
+    if config_update_changes_credentials(&body)
+        && !auth_context
+            .as_ref()
+            .map(|context| context.role.can_manage_credentials())
+            .unwrap_or(true)
+    {
+        return Err(ApiError::Forbidden);
+    }
+
     let mut config = (*state.runtime_config.load_full()).clone();
     let before_config = config.clone();
     let mut changed = false;
@@ -550,6 +588,13 @@ pub async fn admin_config_save(
         }
         if let Some(ui_session_auth) = server.get("ui_session_auth").and_then(|v| v.as_bool()) {
             config.server.ui_session_auth = ui_session_auth;
+            changed = true;
+        }
+        if let Some(external_identity) = server.get("external_identity") {
+            config.server.external_identity = serde_json::from_value(external_identity.clone())
+                .map_err(|error| {
+                    ApiError::InvalidRequest(format!("Invalid server.external_identity: {error}"))
+                })?;
             changed = true;
         }
         if let Some(allow_query_api_keys) =
@@ -896,7 +941,7 @@ pub async fn admin_config_save(
             let _ = sqlx::query(
                 "INSERT INTO config_audit_log (actor, action, target_type, before_json, after_json) VALUES (?, ?, ?, ?, ?)",
             )
-            .bind("operator")
+            .bind(audit_actor(auth_context.as_ref()))
             .bind("config_update_rejected")
             .bind("config")
             .bind(serde_json::to_string(&before_config).unwrap_or_default())
@@ -913,7 +958,7 @@ pub async fn admin_config_save(
             "INSERT INTO config_snapshots (version, created_by, source, config_json) VALUES (?, ?, ?, ?)",
         )
         .bind(&before_config.version)
-        .bind("operator")
+        .bind(audit_actor(auth_context.as_ref()))
         .bind("admin_config_save")
         .bind(snapshot_json)
         .execute(&state.db)
@@ -943,7 +988,7 @@ pub async fn admin_config_save(
         let _ = sqlx::query(
             "INSERT INTO config_audit_log (actor, action, target_type) VALUES (?, ?, ?)",
         )
-        .bind("operator")
+        .bind(audit_actor(auth_context.as_ref()))
         .bind("config_update")
         .bind("config")
         .execute(&state.db)
@@ -953,6 +998,39 @@ pub async fn admin_config_save(
     Ok(Json(
         serde_json::json!({"status": "ok", "message": "Config saved and applied without restart"}),
     ))
+}
+
+fn audit_actor(context: Option<&crate::api::auth::AuthContext>) -> String {
+    context
+        .map(crate::api::auth::AuthContext::audit_actor)
+        .unwrap_or_else(|| "operator".to_string())
+}
+
+fn config_update_changes_credentials(body: &serde_json::Value) -> bool {
+    let server_key_changes = body
+        .get("server")
+        .and_then(|server| server.get("master_api_key"))
+        .and_then(|value| value.as_str())
+        .map(|value| !value.is_empty() && !crate::util::redact::is_redacted_secret(value))
+        .unwrap_or(false);
+    if server_key_changes {
+        return true;
+    }
+
+    body.get("providers")
+        .and_then(|providers| providers.as_array())
+        .map(|providers| {
+            providers.iter().any(|provider| {
+                provider
+                    .get("api_key")
+                    .and_then(|value| value.as_str())
+                    .map(|value| {
+                        !value.is_empty() && !crate::util::redact::is_redacted_secret(value)
+                    })
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
 }
 
 pub async fn admin_config_rollback(

--- a/src/app/startup.rs
+++ b/src/app/startup.rs
@@ -361,6 +361,10 @@ pub fn build_router(state: AppState) -> Router {
             axum::routing::get(crate::api::routes::admin_providers),
         )
         .route(
+            "/admin/whoami",
+            axum::routing::get(crate::api::routes::admin_whoami),
+        )
+        .route(
             "/admin/config",
             axum::routing::get(crate::api::routes::admin_config),
         )

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -164,6 +164,7 @@ pub fn run_setup_wizard(target_path: &Path) -> Result<Config, Box<dyn std::error
         server: ServerConfig {
             bind: bind.clone(),
             master_api_key,
+            external_identity: Default::default(),
             allowed_cors_origins: vec![],
             allow_query_api_keys: false,
             ui_session_auth: use_master_key,

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -47,6 +47,16 @@ pub fn expand_provider_config(
 pub fn expand_all(cfg: &crate::config::schema::Config) -> crate::config::schema::Config {
     let mut cfg = cfg.clone();
     cfg.server.master_api_key = expand_env_vars(&cfg.server.master_api_key);
+    cfg.server.external_identity.user_header =
+        expand_env_vars(&cfg.server.external_identity.user_header);
+    cfg.server.external_identity.email_header =
+        expand_env_vars(&cfg.server.external_identity.email_header);
+    cfg.server.external_identity.name_header =
+        expand_env_vars(&cfg.server.external_identity.name_header);
+    cfg.server.external_identity.groups_header =
+        expand_env_vars(&cfg.server.external_identity.groups_header);
+    cfg.server.external_identity.group_delimiter =
+        expand_env_vars(&cfg.server.external_identity.group_delimiter);
     cfg.providers = cfg
         .providers
         .into_iter()

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -31,6 +31,8 @@ pub struct ServerConfig {
     #[serde(default)]
     pub master_api_key: String,
     #[serde(default)]
+    pub external_identity: ExternalIdentityConfig,
+    #[serde(default)]
     pub allowed_cors_origins: Vec<String>,
     #[serde(default)]
     pub allow_query_api_keys: bool,
@@ -49,12 +51,64 @@ impl Default for ServerConfig {
         Self {
             bind: default_bind(),
             master_api_key: String::new(),
+            external_identity: ExternalIdentityConfig::default(),
             allowed_cors_origins: Vec::new(),
             allow_query_api_keys: false,
             ui_session_auth: false,
             ui_enabled: true,
             ui_path: default_ui_path(),
             request_timeout_ms: default_request_timeout_ms(),
+        }
+    }
+}
+
+/// Trusted reverse-proxy identity headers for admin UI/API access.
+///
+/// TokenScavenger does not perform the OAuth/OIDC browser dance itself. Instead,
+/// an operator can place it behind an identity-aware proxy such as oauth2-proxy,
+/// Dex, Authelia, Keycloak, Zitadel, or a cloud load balancer that authenticates
+/// Google, GitHub, Microsoft, or another OIDC provider and forwards identity
+/// headers to TokenScavenger.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalIdentityConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_external_user_header")]
+    pub user_header: String,
+    #[serde(default = "default_external_email_header")]
+    pub email_header: String,
+    #[serde(default = "default_external_name_header")]
+    pub name_header: String,
+    #[serde(default = "default_external_groups_header")]
+    pub groups_header: String,
+    #[serde(default = "default_external_group_delimiter")]
+    pub group_delimiter: String,
+    #[serde(default)]
+    pub read_only_groups: Vec<String>,
+    #[serde(default)]
+    pub operator_groups: Vec<String>,
+    #[serde(default)]
+    pub config_editor_groups: Vec<String>,
+    #[serde(default)]
+    pub credential_manager_groups: Vec<String>,
+    #[serde(default)]
+    pub admin_groups: Vec<String>,
+}
+
+impl Default for ExternalIdentityConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            user_header: default_external_user_header(),
+            email_header: default_external_email_header(),
+            name_header: default_external_name_header(),
+            groups_header: default_external_groups_header(),
+            group_delimiter: default_external_group_delimiter(),
+            read_only_groups: Vec::new(),
+            operator_groups: Vec::new(),
+            config_editor_groups: Vec::new(),
+            credential_manager_groups: Vec::new(),
+            admin_groups: Vec::new(),
         }
     }
 }
@@ -242,6 +296,21 @@ fn default_ui_path() -> String {
 }
 fn default_request_timeout_ms() -> u64 {
     120_000
+}
+fn default_external_user_header() -> String {
+    "x-auth-request-user".to_string()
+}
+fn default_external_email_header() -> String {
+    "x-auth-request-email".to_string()
+}
+fn default_external_name_header() -> String {
+    "x-auth-request-preferred-username".to_string()
+}
+fn default_external_groups_header() -> String {
+    "x-auth-request-groups".to_string()
+}
+fn default_external_group_delimiter() -> String {
+    ",".to_string()
 }
 fn default_db_path() -> String {
     "tokenscavenger.db".to_string()

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -1,5 +1,5 @@
 use crate::config::schema::Config;
-use reqwest::header::HeaderValue;
+use reqwest::header::{HeaderName, HeaderValue};
 use url::Url;
 
 /// Result of config validation.
@@ -22,6 +22,46 @@ pub fn validate_config(cfg: &Config) -> ConfigValidation {
             v.errors.push(format!(
                 "server.allowed_cors_origins contains an invalid header value: {origin}"
             ));
+        }
+    }
+    if cfg.server.external_identity.enabled {
+        for (field, value) in [
+            (
+                "server.external_identity.user_header",
+                &cfg.server.external_identity.user_header,
+            ),
+            (
+                "server.external_identity.email_header",
+                &cfg.server.external_identity.email_header,
+            ),
+            (
+                "server.external_identity.name_header",
+                &cfg.server.external_identity.name_header,
+            ),
+            (
+                "server.external_identity.groups_header",
+                &cfg.server.external_identity.groups_header,
+            ),
+        ] {
+            if value.parse::<HeaderName>().is_err() {
+                v.errors
+                    .push(format!("{field} must be a valid HTTP header name"));
+            }
+        }
+        let has_role_group = !cfg.server.external_identity.read_only_groups.is_empty()
+            || !cfg.server.external_identity.operator_groups.is_empty()
+            || !cfg.server.external_identity.config_editor_groups.is_empty()
+            || !cfg
+                .server
+                .external_identity
+                .credential_manager_groups
+                .is_empty()
+            || !cfg.server.external_identity.admin_groups.is_empty();
+        if !has_role_group {
+            v.warnings.push(
+                "server.external_identity.enabled is true but no role groups are configured"
+                    .to_string(),
+            );
         }
     }
 
@@ -192,6 +232,29 @@ mod tests {
                 .any(|e| e.contains("allowed_cors_origins"))
         );
         assert!(result.errors.iter().any(|e| e.contains("api_key")));
+    }
+
+    #[test]
+    fn test_validate_rejects_invalid_external_identity_header_names() {
+        let cfg = Config {
+            server: ServerConfig {
+                external_identity: ExternalIdentityConfig {
+                    enabled: true,
+                    user_header: "bad header".into(),
+                    admin_groups: vec!["admins".into()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let result = validate_config(&cfg);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|error| error.contains("external_identity.user_header"))
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -630,6 +630,248 @@ async fn test_optional_ui_session_cookie_authenticates_browser_requests() {
 }
 
 #[tokio::test]
+async fn test_external_identity_headers_authenticate_admin_ui_with_role() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let mut external_identity = tokenscavenger::config::schema::ExternalIdentityConfig {
+        enabled: true,
+        read_only_groups: vec!["tokenscavenger-viewers".into()],
+        ..Default::default()
+    };
+    external_identity.groups_header = "x-forwarded-groups".into();
+    let config = Config {
+        server: ServerConfig {
+            external_identity,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let router = tokenscavenger::app::startup::build_router(AppState::new(
+        config,
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    ));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/admin/whoami")
+                .header("x-auth-request-user", "alice")
+                .header("x-auth-request-email", "alice@example.com")
+                .header("x-forwarded-groups", "tokenscavenger-viewers")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 4096)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["source"], "external_identity");
+    assert_eq!(json["email"], "alice@example.com");
+    assert_eq!(json["role"], "read_only");
+}
+
+#[tokio::test]
+async fn test_external_identity_headers_do_not_authorize_openai_api() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let external_identity = tokenscavenger::config::schema::ExternalIdentityConfig {
+        enabled: true,
+        admin_groups: vec!["tokenscavenger-admins".into()],
+        ..Default::default()
+    };
+    let config = Config {
+        server: ServerConfig {
+            master_api_key: "secret".into(),
+            external_identity,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let router = tokenscavenger::app::startup::build_router(AppState::new(
+        config,
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    ));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/v1/models")
+                .header("x-auth-request-user", "alice")
+                .header("x-auth-request-groups", "tokenscavenger-admins")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_external_identity_without_master_key_does_not_protect_openai_api() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let external_identity = tokenscavenger::config::schema::ExternalIdentityConfig {
+        enabled: true,
+        admin_groups: vec!["tokenscavenger-admins".into()],
+        ..Default::default()
+    };
+    let config = Config {
+        server: ServerConfig {
+            external_identity,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let router = tokenscavenger::app::startup::build_router(AppState::new(
+        config,
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    ));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/v1/models")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_external_identity_read_only_role_cannot_mutate_config() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let external_identity = tokenscavenger::config::schema::ExternalIdentityConfig {
+        enabled: true,
+        read_only_groups: vec!["tokenscavenger-viewers".into()],
+        ..Default::default()
+    };
+    let config = Config {
+        server: ServerConfig {
+            external_identity,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let router = tokenscavenger::app::startup::build_router(AppState::new(
+        config,
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    ));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/admin/config")
+                .method("PUT")
+                .header("content-type", "application/json")
+                .header("x-auth-request-user", "alice")
+                .header("x-auth-request-groups", "tokenscavenger-viewers")
+                .body(Body::from(
+                    json!({"routing": {"free_first": false}}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_config_editor_cannot_change_credentials_without_credential_role() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let external_identity = tokenscavenger::config::schema::ExternalIdentityConfig {
+        enabled: true,
+        config_editor_groups: vec!["tokenscavenger-editors".into()],
+        credential_manager_groups: vec!["tokenscavenger-credential-managers".into()],
+        ..Default::default()
+    };
+    let config = Config {
+        server: ServerConfig {
+            external_identity,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let router = tokenscavenger::app::startup::build_router(AppState::new(
+        config,
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    ));
+
+    let rejected = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/admin/config")
+                .method("PUT")
+                .header("content-type", "application/json")
+                .header("x-auth-request-user", "alice")
+                .header("x-auth-request-groups", "tokenscavenger-editors")
+                .body(Body::from(
+                    json!({"providers": [{"id": "groq", "api_key": "new-secret"}]}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rejected.status(), StatusCode::FORBIDDEN);
+
+    let accepted = router
+        .oneshot(
+            Request::builder()
+                .uri("/admin/config")
+                .method("PUT")
+                .header("content-type", "application/json")
+                .header("x-auth-request-user", "bob")
+                .header(
+                    "x-auth-request-groups",
+                    "tokenscavenger-credential-managers",
+                )
+                .body(Body::from(
+                    json!({"providers": [{"id": "groq", "api_key": "new-secret"}]}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), StatusCode::OK);
+}
+
+#[tokio::test]
 async fn test_ui_redirects_to_login_when_session_auth_required() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     sqlx::migrate!("src/db/migrations")


### PR DESCRIPTION
## Summary
- add role-aware admin authorization for read-only, operator, config editor, credential manager, and admin access
- add trusted reverse-proxy external identity headers for admin UI/API access, compatible with OIDC-capable proxies for Google, GitHub, Microsoft, and OSS IdPs
- add /admin/whoami, config schema, validation, docs, roadmap, changelog, and website updates

## Security notes
- external identity headers are accepted only when explicitly enabled
- external identity authorizes only /ui and /admin/*, not OpenAI-compatible /v1/* traffic
- credential-bearing config changes require credential_manager or admin
- invalid external identity header names fail config validation

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo test --all-features
- pnpm --dir docs build
- git diff --check
- local smoke test for /admin/whoami, read-only denial, credential-manager acceptance, /v1 header isolation, and master-key compatibility