### PR TITLE
Complete deployment security and team controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
     steps:
@@ -202,6 +204,21 @@ jobs:
           done
           cat checksums.txt
 
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          output-file: tokenscavenger-${{ needs.prepare.outputs.new_version }}.spdx.json
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            dist/**/tokenscavenger-v*
+            checksums.txt
+            tokenscavenger-${{ needs.prepare.outputs.new_version }}.spdx.json
+
       - name: Build release notes
         run: |
           python3 scripts/changelog_release.py extract \
@@ -228,6 +245,11 @@ jobs:
           ### Checksums (SHA256)
 
           See `checksums.txt` attached below.
+
+          ### SBOM and Provenance
+
+          This release includes an SPDX SBOM and GitHub artifact attestations for
+          the release binaries, checksums, and SBOM.
 
           ### First Run
 
@@ -262,3 +284,4 @@ jobs:
           files: |
             dist/**/tokenscavenger-v*
             checksums.txt
+            tokenscavenger-${{ needs.prepare.outputs.new_version }}.spdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Zitadel.
 - Added `GET /admin/whoami` for validating the authenticated admin principal,
   auth source, resolved role, and credential-management permission.
+- Added encrypted credential persistence for runtime overrides using an
+  operator-supplied AES-GCM key.
+- Added opt-in self-update checks and apply flow through the admin API/UI, with
+  checksum verification and same-argument restart.
+- Added configurable retention windows for usage, health, audit, and request
+  trace data.
+- Added Homebrew formula and Kubernetes manifest starters.
+- Added release SBOM generation and GitHub artifact provenance attestations.
 
 ### Changed
+
+- Documented restore drills, migration rollback guidance, and release
+  verification surfaces for deployment operators.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,47 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +128,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -428,6 +478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,7 +754,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -711,6 +790,17 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -844,6 +934,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "flume"
@@ -1031,6 +1131,16 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1392,6 +1502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1740,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,6 +1852,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -1859,6 +1994,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2515,6 +2662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,11 +3100,13 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tokenscavenger"
 version = "0.3.3"
 dependencies = [
+ "aes-gcm",
  "arc-swap",
  "askama",
  "async-stream",
  "async-trait",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "clap",
@@ -2967,6 +3122,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -2979,6 +3135,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -3256,6 +3413,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -4030,7 +4197,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ sqlx = { version = "0.8", default-features = false, features = ["sqlite", "runti
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1.1"
+base64 = "0.22"
+aes-gcm = "0.10"
+sha2 = "0.10"
 
 # CLI
 clap = { version = "4.6", features = ["derive"] }
@@ -57,6 +60,7 @@ url = "2.5"
 rand = "0.10"
 regex-lite = "0.1"
 async-stream = "0.3"
+zip = { version = "4.6", default-features = false, features = ["deflate"] }
 
 # Templating for UI
 askama = "0.15"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@
 - **Embedded web UI** with live dashboard, observability, logs, and config editor
 - **Team-ready admin auth** with role-aware access and external identity headers
   from OIDC-capable reverse proxies
+- **Deployment controls** for encrypted credential persistence, self-update,
+  SBOM/provenance release artifacts, retention, Homebrew, and Kubernetes
 - **SQLite persistence** (WAL mode) for usage accounting and audit log
 - **Interactive setup wizard** and CLI tools
 - **Single static binary** (~15–25 MB)
@@ -345,7 +347,8 @@ The workflow:
 
 - Uses the current `Cargo.toml` version or bumps it, then creates a git tag (`vX.Y.Z`)
 - Builds binaries for Linux (x86_64), signed/notarized macOS (ARM64), and Windows (x86_64)
-- Creates a GitHub release with all binaries and checksums attached
+- Creates a GitHub release with all binaries, checksums, an SPDX SBOM, and
+  GitHub artifact attestations attached
 - Generates release notes from commit history
 
 macOS signing and notarization require these GitHub repository secrets:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ This roadmap is intentionally focused on five high-value enhancements. Each one 
 
 ## 5. Deployment, Security, And Team Controls
 
-**Status:** In progress. Role-aware admin access and external identity integration are implemented for v0.3.4.
+**Status:** Implemented in v0.3.4.
 
 **Current baseline:** The project already documents static binary builds, Docker, Docker Compose, systemd, reverse proxy deployment, Prometheus scraping, health checks, SQLite backup, and upgrade steps in `documentation/deployment.md`. It also supports bearer auth, CORS controls, query-key opt-in, session-cookie UI auth, secret redaction, and release artifacts with checksums.
 
@@ -77,11 +77,11 @@ This roadmap is intentionally focused on five high-value enhancements. Each one 
 **What good looks like:**
 
 - [x] Role-aware admin access for read-only operators, config editors, and credential managers.
-- Optional encrypted provider credential storage using OS keychains or an operator-supplied encryption key.
-- Cryptographically signed release artifacts, SBOM generation, and documented verification steps beyond the existing checksum release flow.
-- Self-update support that alerts admins when a new TokenScavenger release is available, offers an admin UI CTA to apply it, installs the new version safely, and reloads the app/UI onto the updated binary by restarting with the same executable arguments and configuration used for the current process.
-- Homebrew packaging and Kubernetes manifests that complement the existing binary, Docker, Docker Compose, and systemd deployment docs.
-- Restore drills, retention policy controls, and migration rollback guidance for SQLite state, extending the current backup and automatic migration docs.
+- [x] Optional encrypted provider credential storage using OS keychains or an operator-supplied encryption key.
+- [x] Cryptographically signed release artifacts, SBOM generation, and documented verification steps beyond the existing checksum release flow.
+- [x] Self-update support that alerts admins when a new TokenScavenger release is available, offers an admin UI CTA to apply it, installs the new version safely, and reloads the app/UI onto the updated binary by restarting with the same executable arguments and configuration used for the current process.
+- [x] Homebrew packaging and Kubernetes manifests that complement the existing binary, Docker, Docker Compose, and systemd deployment docs.
+- [x] Restore drills, retention policy controls, and migration rollback guidance for SQLite state, extending the current backup and automatic migration docs.
 - [x] Optional external identity integration for the admin UI, such as OIDC reverse-proxy headers, while keeping local auth simple.
 
 ## How To Contribute

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tokenscavenger-config
+data:
+  tokenscavenger.toml: |
+    [server]
+    bind = "0.0.0.0:8000"
+    master_api_key = "${TOKENSCAVENGER_MASTER_KEY}"
+
+    [database]
+    path = "/data/tokenscavenger.db"
+
+    [metrics]
+    enabled = true
+
+    [security.credential_encryption]
+    enabled = true
+    key_env = "TOKENSCAVENGER_CREDENTIAL_KEY"
+
+    [updates]
+    enabled = false

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tokenscavenger
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tokenscavenger
+  template:
+    metadata:
+      labels:
+        app: tokenscavenger
+    spec:
+      containers:
+        - name: tokenscavenger
+          image: ghcr.io/kabudu/token-scavenger:REPLACE_WITH_VERSION
+          args: ["--config", "/config/tokenscavenger.toml"]
+          ports:
+            - name: http
+              containerPort: 8000
+          env:
+            - name: TOKENSCAVENGER_MASTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tokenscavenger-secrets
+                  key: master-api-key
+            - name: TOKENSCAVENGER_CREDENTIAL_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: tokenscavenger-secrets
+                  key: credential-encryption-key
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: config
+          configMap:
+            name: tokenscavenger-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: tokenscavenger-data

--- a/deploy/kubernetes/pvc.yaml
+++ b/deploy/kubernetes/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tokenscavenger-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/kubernetes/service.yaml
+++ b/deploy/kubernetes/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tokenscavenger
+spec:
+  selector:
+    app: tokenscavenger
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/documentation/api-behavior.md
+++ b/documentation/api-behavior.md
@@ -19,6 +19,8 @@ TokenScavenger exposes OpenAI-compatible HTTP endpoints while routing each reque
 | `GET /admin/incidents` | Incident feed derived from provider health events, route failures, and config audit history. |
 | `GET /admin/diagnostics/bundle` | Redacted diagnostic bundle for support and incident handoff. |
 | `GET /admin/whoami` | Current authenticated admin principal, auth source, role, and credential-management permission. |
+| `GET /admin/update/check` | Self-update status for the configured GitHub release source. |
+| `POST /admin/update/apply` | Download, checksum-verify, install, and restart onto the latest release when self-update is enabled. |
 
 ## Error Shape
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -40,6 +40,21 @@ level = "info"                      # trace | debug | info | warn | error
 enabled = true                      # Enable Prometheus metrics endpoint
 path = "/metrics"                   # Metrics endpoint path
 
+[security.credential_encryption]
+enabled = false                     # Encrypt credential-bearing runtime overrides
+key_env = "TOKENSCAVENGER_CREDENTIAL_KEY"
+
+[retention]
+usage_days = 30
+health_event_days = 30
+audit_days = 90
+request_trace_days = 30
+
+[updates]
+enabled = false                     # Enable admin UI/API self-update checks
+github_repo = "kabudu/token-scavenger"
+check_interval_secs = 21600
+
 [routing]
 free_first = true                   # Always prefer free tier first
 allow_paid_fallback = false         # Allow fallback to paid providers
@@ -160,6 +175,47 @@ admin_groups = ["tokenscavenger-admins"]
 |-------|---------|-------------|
 | `enabled` | `true` | Whether to expose Prometheus metrics. |
 | `path` | `"/metrics"` | HTTP endpoint path for Prometheus scrape. |
+
+### `[security.credential_encryption]`
+
+When enabled, TokenScavenger encrypts credential-bearing values before writing
+runtime override files created by the admin UI or CLI hot-reload flow. Runtime
+memory still holds decrypted values so provider adapters can authenticate
+normally.
+
+The key is supplied by the environment variable named in `key_env`. TokenScavenger
+derives a 256-bit AES-GCM key from that value. Keep this key stable across
+restarts; encrypted override files cannot be decrypted without it.
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Encrypts persisted runtime override secrets when true. |
+| `key_env` | `"TOKENSCAVENGER_CREDENTIAL_KEY"` | Environment variable containing the operator-supplied encryption key. |
+
+Encrypted values are stored with the `tsenc:v1:` prefix. Base config files may
+still contain plaintext secrets if operators write them manually; use environment
+variable references there for best hygiene.
+
+### `[retention]`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `usage_days` | `30` | Retention window for usage events. |
+| `health_event_days` | `30` | Retention window for provider health events. |
+| `audit_days` | `90` | Retention window for config audit entries. |
+| `request_trace_days` | `30` | Retention window for request trace events. |
+
+### `[updates]`
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `enabled` | `false` | Enables `/admin/update/check`, `/admin/update/apply`, and the admin UI update banner. |
+| `github_repo` | `"kabudu/token-scavenger"` | GitHub repository used for release discovery. |
+| `check_interval_secs` | `21600` | Intended operator polling interval for update checks. |
+
+When applying an update, TokenScavenger downloads the platform release asset,
+verifies it against `checksums.txt`, replaces the current executable, and
+restarts with the same executable arguments.
 
 ### `[routing]`
 

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -172,6 +172,38 @@ setting its own trusted values. TokenScavenger expects these default headers:
 Use `GET /admin/whoami` after deployment to verify the resolved identity source,
 subject, role, and credential-management permission.
 
+### Credential Encryption
+
+Enable encrypted runtime override storage when admins will enter provider keys
+through the UI or CLI hot-reload flow:
+
+```toml
+[security.credential_encryption]
+enabled = true
+key_env = "TOKENSCAVENGER_CREDENTIAL_KEY"
+```
+
+Set `TOKENSCAVENGER_CREDENTIAL_KEY` in the service manager, container secret, or
+Kubernetes Secret. Keep it stable and backed up; encrypted `*.overrides.toml`
+files cannot be restored without the same key.
+
+### Self-Update
+
+Self-update is opt-in:
+
+```toml
+[updates]
+enabled = true
+github_repo = "kabudu/token-scavenger"
+```
+
+The admin UI checks `/admin/update/check` and displays an update CTA when a
+newer GitHub release exists. Applying an update downloads the matching platform
+asset, verifies it against `checksums.txt`, replaces the current executable, and
+restarts TokenScavenger with the same command-line arguments. Use a process
+manager such as systemd, launchd, Docker, or Kubernetes for additional restart
+supervision.
+
 ### Reverse Proxy (Nginx)
 
 ```nginx
@@ -233,7 +265,29 @@ sqlite3 tokenscavenger.db ".backup 'backup-$(date +%Y%m%d).db'"
 
 ### Retention
 
-Usage and health event data accumulates over time. The default schema includes timestamp fields for implementing retention cleanup. Configure retention via config in a future release.
+Usage, health, audit, and request trace data are cleaned up by the background
+retention task. Configure windows in days:
+
+```toml
+[retention]
+usage_days = 30
+health_event_days = 30
+audit_days = 90
+request_trace_days = 30
+```
+
+### Restore Drill
+
+1. Stop TokenScavenger.
+2. Copy the backup database into place.
+3. Restore the matching config and overrides files.
+4. Ensure `TOKENSCAVENGER_CREDENTIAL_KEY` matches the value used when encrypted overrides were created.
+5. Start TokenScavenger and verify `/readyz`, `/admin/whoami`, `/admin/config`, and `/ui/observability`.
+
+Migration rollback is file-based: restore the database backup taken before the
+upgrade and run the previous binary with the same config. Runtime config
+snapshots can also be rolled back through `/admin/config/rollback` when the
+database itself is healthy.
 
 ## Monitoring
 
@@ -269,6 +323,14 @@ Ready-to-import monitoring starters live in `monitoring/`:
 
 - `monitoring/grafana-dashboard.json`
 - `monitoring/prometheus-alerts.yml`
+
+Release artifacts also include `checksums.txt`, an SPDX SBOM, and GitHub
+artifact attestations for provenance verification.
+
+## Packaging Starters
+
+- Homebrew formula template: `packaging/homebrew/tokenscavenger.rb`
+- Kubernetes manifests: `deploy/kubernetes/`
 
 ### Logging
 

--- a/packaging/homebrew/tokenscavenger.rb
+++ b/packaging/homebrew/tokenscavenger.rb
@@ -1,0 +1,36 @@
+class Tokenscavenger < Formula
+  desc "Self-hosted OpenAI-compatible LLM proxy/router"
+  homepage "https://github.com/kabudu/token-scavenger"
+  version "0.3.4"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/kabudu/token-scavenger/releases/download/v#{version}/tokenscavenger-v#{version}-aarch64-apple-darwin.zip"
+      sha256 "REPLACE_WITH_RELEASE_SHA256"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/kabudu/token-scavenger/releases/download/v#{version}/tokenscavenger-v#{version}-x86_64-unknown-linux-gnu"
+      sha256 "REPLACE_WITH_RELEASE_SHA256"
+    end
+  end
+
+  def install
+    candidate = Dir["tokenscavenger*"].find { |path| File.file?(path) }
+    bin.install candidate => "tokenscavenger"
+  end
+
+  service do
+    run [opt_bin/"tokenscavenger", "--config", "#{etc}/tokenscavenger/tokenscavenger.toml"]
+    keep_alive true
+    working_dir var
+    log_path var/"log/tokenscavenger.log"
+    error_log_path var/"log/tokenscavenger.err.log"
+  end
+
+  test do
+    assert_match "tokenscavenger", shell_output("#{bin}/tokenscavenger --help")
+  end
+end

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -614,6 +614,28 @@ pub async fn admin_config_save(
         }
     }
 
+    // --- Security, retention, and update settings ---
+    if let Some(security) = body.get("security") {
+        config.security = serde_json::from_value(security.clone()).map_err(|error| {
+            ApiError::InvalidRequest(format!("Invalid security config: {error}"))
+        })?;
+        changed = true;
+    }
+
+    if let Some(retention) = body.get("retention") {
+        config.retention = serde_json::from_value(retention.clone()).map_err(|error| {
+            ApiError::InvalidRequest(format!("Invalid retention config: {error}"))
+        })?;
+        changed = true;
+    }
+
+    if let Some(updates) = body.get("updates") {
+        config.updates = serde_json::from_value(updates.clone()).map_err(|error| {
+            ApiError::InvalidRequest(format!("Invalid updates config: {error}"))
+        })?;
+        changed = true;
+    }
+
     // --- Routing settings ---
     if let Some(routing) = body.get("routing") {
         if let Some(free) = routing.get("free_first").and_then(|v| v.as_bool()) {
@@ -982,7 +1004,8 @@ pub async fn admin_config_save(
         }
 
         // Persist runtime overrides to disk
-        let _ = crate::config::overrides::save_runtime_overrides(config_path, &config);
+        crate::config::overrides::save_runtime_overrides(config_path, &config)
+            .map_err(|error| ApiError::InternalError(error.to_string()))?;
 
         // Record audit entry
         let _ = sqlx::query(
@@ -1066,7 +1089,8 @@ pub async fn admin_config_rollback(
     if let Ok(mut engine) = state.route_engine.write() {
         engine.update_config(config.clone());
     }
-    let _ = crate::config::overrides::save_runtime_overrides(&state.boot_config_file, &config);
+    crate::config::overrides::save_runtime_overrides(&state.boot_config_file, &config)
+        .map_err(|error| ApiError::InternalError(error.to_string()))?;
     let _ = sqlx::query(
         "INSERT INTO config_audit_log (actor, action, target_type, target_id) VALUES (?, ?, ?, ?)",
     )
@@ -1270,4 +1294,25 @@ pub async fn admin_pricing_backfill(
         .await
         .map_err(|e| ApiError::InternalError(e.to_string()))?;
     Ok(Json(result))
+}
+
+pub async fn admin_update_check(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let status = crate::update::check_for_update(&state.config().updates)
+        .await
+        .map_err(|error| ApiError::InternalError(error.to_string()))?;
+    Ok(Json(serde_json::to_value(status).unwrap_or_default()))
+}
+
+pub async fn admin_update_apply(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let status = crate::update::apply_update(state)
+        .await
+        .map_err(|error| ApiError::InternalError(error.to_string()))?;
+    Ok(Json(serde_json::json!({
+        "status": "restart_scheduled",
+        "update": status
+    })))
 }

--- a/src/app/startup.rs
+++ b/src/app/startup.rs
@@ -40,6 +40,9 @@ pub async fn startup(config_path: &Path) -> Result<StartupResult, Box<dyn std::e
         config.server = overrides.server;
         config.database = overrides.database;
         config.metrics = overrides.metrics;
+        config.security = overrides.security;
+        config.retention = overrides.retention;
+        config.updates = overrides.updates;
         config.routing = overrides.routing;
         config.resilience = overrides.resilience;
         info!("Runtime overrides merged successfully");
@@ -303,9 +306,23 @@ fn spawn_background_tasks(base_state: AppState) {
             let mut shutdown_rx = s.shutdown_rx.clone();
             tokio::select! {
                 _ = tokio::time::sleep(std::time::Duration::from_secs(3600)) => {
-                    let _ = sqlx::query("DELETE FROM usage_events WHERE timestamp < datetime('now', '-30 days')").execute(&s.db).await;
-                    let _ = sqlx::query("DELETE FROM provider_health_events WHERE recorded_at < datetime('now', '-30 days')").execute(&s.db).await;
-                    let _ = sqlx::query("DELETE FROM config_audit_log WHERE created_at < datetime('now', '-90 days')").execute(&s.db).await;
+                    let retention = s.config().retention.clone();
+                    let usage_window = format!("-{} days", retention.usage_days);
+                    let health_window = format!("-{} days", retention.health_event_days);
+                    let audit_window = format!("-{} days", retention.audit_days);
+                    let trace_window = format!("-{} days", retention.request_trace_days);
+                    let _ = sqlx::query("DELETE FROM usage_events WHERE timestamp < datetime('now', ?)")
+                        .bind(&usage_window)
+                        .execute(&s.db).await;
+                    let _ = sqlx::query("DELETE FROM provider_health_events WHERE recorded_at < datetime('now', ?)")
+                        .bind(&health_window)
+                        .execute(&s.db).await;
+                    let _ = sqlx::query("DELETE FROM config_audit_log WHERE created_at < datetime('now', ?)")
+                        .bind(&audit_window)
+                        .execute(&s.db).await;
+                    let _ = sqlx::query("DELETE FROM request_trace_events WHERE recorded_at < datetime('now', ?)")
+                        .bind(&trace_window)
+                        .execute(&s.db).await;
                     info!("Retention cleanup complete");
                 }
                 _ = shutdown_rx.changed() => { if *shutdown_rx.borrow() { break; } }
@@ -464,6 +481,14 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/admin/pricing/backfill",
             axum::routing::post(crate::api::routes::admin_pricing_backfill),
+        )
+        .route(
+            "/admin/update/check",
+            axum::routing::get(crate::api::routes::admin_update_check),
+        )
+        .route(
+            "/admin/update/apply",
+            axum::routing::post(crate::api::routes::admin_update_apply),
         )
         .layer(from_fn_with_state(
             state.clone(),

--- a/src/cli/config_cmd.rs
+++ b/src/cli/config_cmd.rs
@@ -503,6 +503,7 @@ fn build_reload_payload(config: &Config) -> serde_json::Value {
         "server": {
             "bind": config.server.bind,
             "master_api_key": config.server.master_api_key,
+            "external_identity": config.server.external_identity,
             "allowed_cors_origins": config.server.allowed_cors_origins,
             "allow_query_api_keys": config.server.allow_query_api_keys,
             "ui_session_auth": config.server.ui_session_auth,
@@ -510,6 +511,9 @@ fn build_reload_payload(config: &Config) -> serde_json::Value {
             "ui_path": config.server.ui_path,
             "request_timeout_ms": config.server.request_timeout_ms,
         },
+        "security": config.security,
+        "retention": config.retention,
+        "updates": config.updates,
         "routing": {
             "free_first": config.routing.free_first,
             "allow_paid_fallback": config.routing.allow_paid_fallback,

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -184,6 +184,9 @@ pub fn run_setup_wizard(target_path: &Path) -> Result<Config, Box<dyn std::error
             enabled: true,
             path: "/metrics".into(),
         },
+        security: Default::default(),
+        retention: Default::default(),
+        updates: Default::default(),
         routing: RoutingConfig {
             free_first,
             allow_paid_fallback: allow_paid,

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -47,6 +47,9 @@ pub fn expand_provider_config(
 pub fn expand_all(cfg: &crate::config::schema::Config) -> crate::config::schema::Config {
     let mut cfg = cfg.clone();
     cfg.server.master_api_key = expand_env_vars(&cfg.server.master_api_key);
+    cfg.security.credential_encryption.key_env =
+        expand_env_vars(&cfg.security.credential_encryption.key_env);
+    cfg.updates.github_repo = expand_env_vars(&cfg.updates.github_repo);
     cfg.server.external_identity.user_header =
         expand_env_vars(&cfg.server.external_identity.user_header);
     cfg.server.external_identity.email_header =

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -13,6 +13,8 @@ pub fn load_config(path: &Path) -> Result<Config, ConfigLoadError> {
 
     // Apply env var expansion
     cfg = env::expand_all(&cfg);
+    crate::util::credentials::decrypt_config(&mut cfg)
+        .map_err(|error| ConfigLoadError::Credentials(error.to_string()))?;
 
     // Validate
     let validation = validate_config(&cfg);
@@ -27,6 +29,8 @@ pub fn load_config(path: &Path) -> Result<Config, ConfigLoadError> {
 pub fn load_config_from_str(s: &str) -> Result<Config, ConfigLoadError> {
     let mut cfg: Config = toml::from_str(s).map_err(|e| ConfigLoadError::Parse(e.to_string()))?;
     cfg = env::expand_all(&cfg);
+    crate::util::credentials::decrypt_config(&mut cfg)
+        .map_err(|error| ConfigLoadError::Credentials(error.to_string()))?;
     let validation = validate_config(&cfg);
     if !validation.errors.is_empty() {
         return Err(ConfigLoadError::Validation(validation));
@@ -42,4 +46,6 @@ pub enum ConfigLoadError {
     Parse(String),
     #[error("Config validation failed")]
     Validation(ConfigValidation),
+    #[error("Credential decryption failed: {0}")]
+    Credentials(String),
 }

--- a/src/config/overrides.rs
+++ b/src/config/overrides.rs
@@ -23,8 +23,12 @@ pub fn save_runtime_overrides(
     config_path: &Path,
     config: &Config,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if config_path.as_os_str().is_empty() {
+        return Ok(());
+    }
     let path = overrides_path(config_path);
-    let toml_str = toml::to_string_pretty(config)?;
+    let stored = crate::util::credentials::encrypted_for_storage(config)?;
+    let toml_str = toml::to_string_pretty(&stored)?;
 
     let header = "# TokenScavenger Runtime Overrides\n".to_string();
     std::fs::write(&path, header + &toml_str)?;
@@ -42,6 +46,15 @@ pub fn load_runtime_overrides(config_path: &Path) -> Option<Config> {
         Ok(s) => match toml::from_str::<Config>(&s) {
             Ok(raw_cfg) => {
                 let cfg = env::expand_all(&raw_cfg);
+                let mut cfg = cfg;
+                if let Err(error) = crate::util::credentials::decrypt_config(&mut cfg) {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %error,
+                        "Runtime overrides failed credential decryption and will be ignored"
+                    );
+                    return None;
+                }
                 let validation = validate_config(&cfg);
                 if !validation.errors.is_empty() {
                     tracing::warn!(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -16,11 +16,83 @@ pub struct Config {
     #[serde(default)]
     pub metrics: MetricsConfig,
     #[serde(default)]
+    pub security: SecurityConfig,
+    #[serde(default)]
+    pub retention: RetentionConfig,
+    #[serde(default)]
+    pub updates: UpdateConfig,
+    #[serde(default)]
     pub routing: RoutingConfig,
     #[serde(default)]
     pub resilience: ResilienceConfig,
     #[serde(default)]
     pub providers: Vec<ProviderConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SecurityConfig {
+    #[serde(default)]
+    pub credential_encryption: CredentialEncryptionConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CredentialEncryptionConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_credential_key_env")]
+    pub key_env: String,
+}
+
+impl Default for CredentialEncryptionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            key_env: default_credential_key_env(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    #[serde(default = "default_usage_retention_days")]
+    pub usage_days: u32,
+    #[serde(default = "default_health_retention_days")]
+    pub health_event_days: u32,
+    #[serde(default = "default_audit_retention_days")]
+    pub audit_days: u32,
+    #[serde(default = "default_trace_retention_days")]
+    pub request_trace_days: u32,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            usage_days: default_usage_retention_days(),
+            health_event_days: default_health_retention_days(),
+            audit_days: default_audit_retention_days(),
+            request_trace_days: default_trace_retention_days(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_update_repo")]
+    pub github_repo: String,
+    #[serde(default = "default_update_check_interval_secs")]
+    pub check_interval_secs: u64,
+}
+
+impl Default for UpdateConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            github_repo: default_update_repo(),
+            check_interval_secs: default_update_check_interval_secs(),
+        }
+    }
 }
 
 /// HTTP server binding and auth settings.
@@ -296,6 +368,27 @@ fn default_ui_path() -> String {
 }
 fn default_request_timeout_ms() -> u64 {
     120_000
+}
+fn default_credential_key_env() -> String {
+    "TOKENSCAVENGER_CREDENTIAL_KEY".to_string()
+}
+fn default_usage_retention_days() -> u32 {
+    30
+}
+fn default_health_retention_days() -> u32 {
+    30
+}
+fn default_audit_retention_days() -> u32 {
+    90
+}
+fn default_trace_retention_days() -> u32 {
+    30
+}
+fn default_update_repo() -> String {
+    "kabudu/token-scavenger".to_string()
+}
+fn default_update_check_interval_secs() -> u64 {
+    21_600
 }
 fn default_external_user_header() -> String {
     "x-auth-request-user".to_string()

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -74,6 +74,41 @@ pub fn validate_config(cfg: &Config) -> ConfigValidation {
             .push("database.max_connections must be > 0".to_string());
     }
 
+    if cfg.security.credential_encryption.enabled
+        && cfg.security.credential_encryption.key_env.trim().is_empty()
+    {
+        v.errors
+            .push("security.credential_encryption.key_env must not be empty".to_string());
+    }
+
+    for (field, value) in [
+        ("retention.usage_days", cfg.retention.usage_days),
+        (
+            "retention.health_event_days",
+            cfg.retention.health_event_days,
+        ),
+        ("retention.audit_days", cfg.retention.audit_days),
+        (
+            "retention.request_trace_days",
+            cfg.retention.request_trace_days,
+        ),
+    ] {
+        if value == 0 {
+            v.errors.push(format!("{field} must be > 0"));
+        }
+    }
+
+    if cfg.updates.enabled {
+        if cfg.updates.github_repo.split('/').count() != 2 {
+            v.errors
+                .push("updates.github_repo must be in owner/repo form".to_string());
+        }
+        if cfg.updates.check_interval_secs < 300 {
+            v.errors
+                .push("updates.check_interval_secs must be at least 300".to_string());
+        }
+    }
+
     // Validate resilience
     if cfg.resilience.max_retries_per_provider > 10 {
         v.warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,6 @@ pub mod providers;
 pub mod resilience;
 pub mod router;
 pub mod ui;
+pub mod update;
 pub mod usage;
 pub mod util;

--- a/src/ui/routes.rs
+++ b/src/ui/routes.rs
@@ -184,6 +184,15 @@ pub fn render_shell(
         </div>
     </div>
     </header>
+    <div id="update-banner" class="mx-8 mt-6 hidden rounded-lg border border-orange-500/30 bg-orange-500/10 px-4 py-3 text-sm text-orange-100">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <span class="font-semibold">Update available</span>
+                <span id="update-banner-text" class="text-orange-100/80"></span>
+            </div>
+            <button id="update-apply-btn" class="btn btn-primary text-xs">Apply Update</button>
+        </div>
+    </div>
     <div class="p-8 space-y-6">
     {}
     </div>
@@ -293,6 +302,34 @@ if (worstState === "Healthy") {{
     bDot.className = "w-2 h-2 rounded-full bg-red-500 animate-pulse";
     bCont.className = "flex items-center gap-2 px-3 py-1.5 rounded-full bg-red-500/10 border border-red-500/20";
 }}
+
+async function checkForUpdate() {{
+    try {{
+        const response = await fetch('/admin/update/check');
+        if (!response.ok) return;
+        const update = await response.json();
+        if (!update.enabled || !update.update_available) return;
+        const banner = document.getElementById('update-banner');
+        const text = document.getElementById('update-banner-text');
+        const button = document.getElementById('update-apply-btn');
+        if (!banner || !text || !button) return;
+        text.innerText = ` v${{update.latest_version}} is available for ${{update.asset_name || 'this platform'}}.`;
+        button.onclick = () => showConfirm('Apply update?', 'TokenScavenger will install the verified release asset, restart with the same arguments, and reload the admin UI.', async () => {{
+            const apply = await fetch('/admin/update/apply', {{ method: 'POST' }});
+            const body = await apply.json().catch(() => ({{}}));
+            if (!apply.ok) {{
+                showModal('Update failed', body, true);
+                return;
+            }}
+            showModal('Restart scheduled', 'The new version is being installed. This page will reload shortly.', false);
+            setTimeout(() => window.location.reload(), 5000);
+        }});
+        banner.classList.remove('hidden');
+    }} catch (_) {{
+        // Update checks are best-effort and should never disturb the admin UI.
+    }}
+}}
+checkForUpdate();
 </script>
 {}
 </body>

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,293 @@
+use crate::app::state::AppState;
+use crate::config::schema::UpdateConfig;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::ffi::OsString;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateStatus {
+    pub enabled: bool,
+    pub current_version: String,
+    pub latest_version: Option<String>,
+    pub update_available: bool,
+    pub release_url: Option<String>,
+    pub asset_name: Option<String>,
+}
+
+pub async fn check_for_update(config: &UpdateConfig) -> Result<UpdateStatus, UpdateError> {
+    let current = env!("CARGO_PKG_VERSION").to_string();
+    if !config.enabled {
+        return Ok(UpdateStatus {
+            enabled: false,
+            current_version: current,
+            latest_version: None,
+            update_available: false,
+            release_url: None,
+            asset_name: None,
+        });
+    }
+
+    let release = fetch_latest_release(config).await?;
+    let latest = release.tag_name.trim_start_matches('v').to_string();
+    let asset_name = platform_asset_name(&release.tag_name);
+    let update_available = version_gt(&latest, &current);
+    Ok(UpdateStatus {
+        enabled: true,
+        current_version: current,
+        latest_version: Some(latest),
+        update_available,
+        release_url: Some(release.html_url),
+        asset_name,
+    })
+}
+
+pub async fn apply_update(state: AppState) -> Result<UpdateStatus, UpdateError> {
+    let config = state.config().updates.clone();
+    if !config.enabled {
+        return Err(UpdateError::Disabled);
+    }
+    let release = fetch_latest_release(&config).await?;
+    let current = env!("CARGO_PKG_VERSION");
+    let latest = release.tag_name.trim_start_matches('v').to_string();
+    if !version_gt(&latest, current) {
+        return Ok(UpdateStatus {
+            enabled: true,
+            current_version: current.to_string(),
+            latest_version: Some(latest),
+            update_available: false,
+            release_url: Some(release.html_url),
+            asset_name: platform_asset_name(&release.tag_name),
+        });
+    }
+
+    let asset_name =
+        platform_asset_name(&release.tag_name).ok_or(UpdateError::UnsupportedPlatform)?;
+    let asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| UpdateError::MissingAsset(asset_name.clone()))?;
+    let checksums = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == "checksums.txt")
+        .ok_or(UpdateError::MissingChecksums)?;
+
+    let client = github_client()?;
+    let binary_bytes = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+    let checksum_text = client
+        .get(&checksums.browser_download_url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    verify_checksum(&asset.name, &binary_bytes, &checksum_text)?;
+
+    let executable = extract_executable(&asset.name, &binary_bytes)?;
+    let current_exe =
+        std::env::current_exe().map_err(|error| UpdateError::Io(error.to_string()))?;
+    let tmp = replacement_path(&current_exe);
+    std::fs::write(&tmp, executable).map_err(|error| UpdateError::Io(error.to_string()))?;
+    make_executable(&tmp)?;
+
+    schedule_replace_and_restart(tmp, std::env::args_os().collect());
+
+    Ok(UpdateStatus {
+        enabled: true,
+        current_version: current.to_string(),
+        latest_version: Some(latest),
+        update_available: true,
+        release_url: Some(release.html_url),
+        asset_name: Some(asset_name),
+    })
+}
+
+fn schedule_replace_and_restart(new_binary: PathBuf, args: Vec<OsString>) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(750)).await;
+        if let Ok(current) = std::env::current_exe() {
+            let backup = current.with_extension("previous");
+            let _ = std::fs::rename(&current, &backup);
+            if std::fs::rename(&new_binary, &current).is_ok() {
+                let mut command = std::process::Command::new(&current);
+                command.args(args.into_iter().skip(1));
+                let _ = command.spawn();
+                std::process::exit(0);
+            } else {
+                let _ = std::fs::rename(&backup, &current);
+            }
+        }
+    });
+}
+
+fn replacement_path(current: &Path) -> PathBuf {
+    current.with_extension(format!("update-{}", chrono::Utc::now().timestamp_millis()))
+}
+
+fn extract_executable(asset_name: &str, bytes: &[u8]) -> Result<Vec<u8>, UpdateError> {
+    if asset_name.ends_with(".zip") {
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes))
+            .map_err(|error| UpdateError::Archive(error.to_string()))?;
+        for index in 0..archive.len() {
+            let mut file = archive
+                .by_index(index)
+                .map_err(|error| UpdateError::Archive(error.to_string()))?;
+            let name = file.name().to_string();
+            if name.ends_with("tokenscavenger") || name.ends_with("tokenscavenger.exe") {
+                let mut extracted = Vec::new();
+                std::io::copy(&mut file, &mut extracted)
+                    .map_err(|error| UpdateError::Io(error.to_string()))?;
+                return Ok(extracted);
+            }
+        }
+        Err(UpdateError::Archive(
+            "archive did not contain tokenscavenger binary".into(),
+        ))
+    } else {
+        Ok(bytes.to_vec())
+    }
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), UpdateError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)
+        .map_err(|error| UpdateError::Io(error.to_string()))?
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms).map_err(|error| UpdateError::Io(error.to_string()))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), UpdateError> {
+    Ok(())
+}
+
+fn verify_checksum(asset_name: &str, bytes: &[u8], checksums: &str) -> Result<(), UpdateError> {
+    let expected = checksums
+        .lines()
+        .find_map(|line| {
+            let mut parts = line.split_whitespace();
+            let hash = parts.next()?;
+            let name = parts.next()?;
+            (name == asset_name).then(|| hash.to_string())
+        })
+        .ok_or_else(|| UpdateError::MissingChecksum(asset_name.to_string()))?;
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(UpdateError::ChecksumMismatch)
+    }
+}
+
+fn platform_asset_name(tag: &str) -> Option<String> {
+    let version = tag.trim_start_matches('v');
+    let suffix = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "aarch64-apple-darwin.zip"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        "x86_64-unknown-linux-gnu"
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        "x86_64-pc-windows-msvc.exe"
+    } else {
+        return None;
+    };
+    Some(format!("tokenscavenger-v{version}-{suffix}"))
+}
+
+fn version_gt(left: &str, right: &str) -> bool {
+    let parse = |value: &str| {
+        value
+            .split('.')
+            .map(|part| part.parse::<u64>().unwrap_or(0))
+            .collect::<Vec<_>>()
+    };
+    parse(left) > parse(right)
+}
+
+async fn fetch_latest_release(config: &UpdateConfig) -> Result<GithubRelease, UpdateError> {
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/latest",
+        config.github_repo
+    );
+    Ok(github_client()?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<GithubRelease>()
+        .await?)
+}
+
+fn github_client() -> Result<reqwest::Client, UpdateError> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .user_agent(format!("tokenscavenger/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(UpdateError::Http)
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UpdateError {
+    #[error("self-update is disabled")]
+    Disabled,
+    #[error("unsupported platform for self-update")]
+    UnsupportedPlatform,
+    #[error("missing release asset {0}")]
+    MissingAsset(String),
+    #[error("release is missing checksums.txt")]
+    MissingChecksums,
+    #[error("checksums.txt has no entry for {0}")]
+    MissingChecksum(String),
+    #[error("downloaded artifact checksum did not match checksums.txt")]
+    ChecksumMismatch,
+    #[error("archive error: {0}")]
+    Archive(String),
+    #[error("I/O error: {0}")]
+    Io(String),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compares_semver_like_versions() {
+        assert!(version_gt("0.3.4", "0.3.3"));
+        assert!(version_gt("0.4.0", "0.3.99"));
+        assert!(!version_gt("0.3.3", "0.3.3"));
+    }
+
+    #[test]
+    fn verifies_matching_checksum() {
+        let bytes = b"hello";
+        let hash = format!("{:x}", Sha256::digest(bytes));
+        let checksums = format!("{hash}  artifact");
+        verify_checksum("artifact", bytes, &checksums).unwrap();
+    }
+}

--- a/src/util/credentials.rs
+++ b/src/util/credentials.rs
@@ -1,0 +1,159 @@
+use crate::config::schema::Config;
+use aes_gcm::aead::rand_core::RngCore;
+use aes_gcm::aead::{Aead, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use sha2::{Digest, Sha256};
+
+const PREFIX: &str = "tsenc:v1:";
+
+pub fn is_encrypted_secret(value: &str) -> bool {
+    value.starts_with(PREFIX)
+}
+
+pub fn decrypt_config(config: &mut Config) -> Result<(), CredentialCryptoError> {
+    let key_env = config.security.credential_encryption.key_env.clone();
+    decrypt_string(&mut config.server.master_api_key, &key_env)?;
+    for provider in &mut config.providers {
+        if let Some(api_key) = provider.api_key.as_mut() {
+            decrypt_string(api_key, &key_env)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn encrypted_for_storage(config: &Config) -> Result<Config, CredentialCryptoError> {
+    let mut stored = config.clone();
+    if !stored.security.credential_encryption.enabled {
+        return Ok(stored);
+    }
+    let key_env = stored.security.credential_encryption.key_env.clone();
+    encrypt_string(&mut stored.server.master_api_key, &key_env)?;
+    for provider in &mut stored.providers {
+        if let Some(api_key) = provider.api_key.as_mut() {
+            encrypt_string(api_key, &key_env)?;
+        }
+    }
+    Ok(stored)
+}
+
+fn encrypt_string(value: &mut String, key_env: &str) -> Result<(), CredentialCryptoError> {
+    if value.is_empty()
+        || is_encrypted_secret(value)
+        || crate::util::redact::is_redacted_secret(value)
+    {
+        return Ok(());
+    }
+    let key = key_from_env(key_env)?;
+    let cipher = Aes256Gcm::new_from_slice(&key).map_err(|_| CredentialCryptoError::InvalidKey)?;
+    let mut nonce_bytes = [0u8; 12];
+    OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+    let ciphertext = cipher
+        .encrypt(nonce, value.as_bytes())
+        .map_err(|_| CredentialCryptoError::Encrypt)?;
+    *value = format!(
+        "{PREFIX}{}:{}",
+        URL_SAFE_NO_PAD.encode(nonce_bytes),
+        URL_SAFE_NO_PAD.encode(ciphertext)
+    );
+    Ok(())
+}
+
+fn decrypt_string(value: &mut String, key_env: &str) -> Result<(), CredentialCryptoError> {
+    if !is_encrypted_secret(value) {
+        return Ok(());
+    }
+    let encoded = value.trim_start_matches(PREFIX);
+    let (nonce, ciphertext) = encoded
+        .split_once(':')
+        .ok_or(CredentialCryptoError::MalformedCiphertext)?;
+    let nonce = URL_SAFE_NO_PAD
+        .decode(nonce)
+        .map_err(|_| CredentialCryptoError::MalformedCiphertext)?;
+    if nonce.len() != 12 {
+        return Err(CredentialCryptoError::MalformedCiphertext);
+    }
+    let ciphertext = URL_SAFE_NO_PAD
+        .decode(ciphertext)
+        .map_err(|_| CredentialCryptoError::MalformedCiphertext)?;
+    let key = key_from_env(key_env)?;
+    let cipher = Aes256Gcm::new_from_slice(&key).map_err(|_| CredentialCryptoError::InvalidKey)?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce), ciphertext.as_ref())
+        .map_err(|_| CredentialCryptoError::Decrypt)?;
+    *value = String::from_utf8(plaintext).map_err(|_| CredentialCryptoError::Decrypt)?;
+    Ok(())
+}
+
+fn key_from_env(key_env: &str) -> Result<[u8; 32], CredentialCryptoError> {
+    let raw = std::env::var(key_env)
+        .map_err(|_| CredentialCryptoError::MissingKey(key_env.to_string()))?;
+    if raw.is_empty() {
+        return Err(CredentialCryptoError::MissingKey(key_env.to_string()));
+    }
+    let digest = Sha256::digest(raw.as_bytes());
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&digest);
+    Ok(key)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CredentialCryptoError {
+    #[error("credential encryption key env var {0} is not set")]
+    MissingKey(String),
+    #[error("credential encryption key is invalid")]
+    InvalidKey,
+    #[error("failed to encrypt credential")]
+    Encrypt,
+    #[error("failed to decrypt credential")]
+    Decrypt,
+    #[error("encrypted credential is malformed")]
+    MalformedCiphertext,
+    #[error("failed to generate encryption nonce: {0}")]
+    Random(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::schema::{CredentialEncryptionConfig, SecurityConfig};
+
+    #[test]
+    fn encrypts_and_decrypts_config_secrets() {
+        unsafe {
+            std::env::set_var("TOKENSCAVENGER_TEST_KEY", "test-key");
+        }
+        let config = Config {
+            security: SecurityConfig {
+                credential_encryption: CredentialEncryptionConfig {
+                    enabled: true,
+                    key_env: "TOKENSCAVENGER_TEST_KEY".into(),
+                },
+            },
+            server: crate::config::schema::ServerConfig {
+                master_api_key: "master-secret".into(),
+                ..Default::default()
+            },
+            providers: vec![crate::config::schema::ProviderConfig {
+                id: "groq".into(),
+                api_key: Some("provider-secret".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut encrypted = encrypted_for_storage(&config).unwrap();
+        assert!(is_encrypted_secret(&encrypted.server.master_api_key));
+        assert!(is_encrypted_secret(
+            encrypted.providers[0].api_key.as_deref().unwrap()
+        ));
+        decrypt_config(&mut encrypted).unwrap();
+        assert_eq!(encrypted.server.master_api_key, "master-secret");
+        assert_eq!(
+            encrypted.providers[0].api_key.as_deref(),
+            Some("provider-secret")
+        );
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod broadcast_layer;
+pub mod credentials;
 pub mod redact;
 pub mod time;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -872,6 +872,80 @@ async fn test_config_editor_cannot_change_credentials_without_credential_role() 
 }
 
 #[tokio::test]
+async fn test_encrypted_runtime_overrides_do_not_store_plaintext_secrets() {
+    unsafe {
+        std::env::set_var("TOKENSCAVENGER_TEST_KEY", "test-key");
+    }
+    let temp_config =
+        std::env::temp_dir().join(format!("tokenscavenger-test-{}.toml", uuid::Uuid::new_v4()));
+    let config = Config {
+        security: tokenscavenger::config::schema::SecurityConfig {
+            credential_encryption: tokenscavenger::config::schema::CredentialEncryptionConfig {
+                enabled: true,
+                key_env: "TOKENSCAVENGER_TEST_KEY".into(),
+            },
+        },
+        server: ServerConfig {
+            master_api_key: "master-secret".into(),
+            ..Default::default()
+        },
+        providers: vec![tokenscavenger::config::schema::ProviderConfig {
+            id: "groq".into(),
+            api_key: Some("provider-secret".into()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    tokenscavenger::config::overrides::save_runtime_overrides(&temp_config, &config).unwrap();
+    let overrides_path = tokenscavenger::config::overrides::overrides_path(&temp_config);
+    let stored = std::fs::read_to_string(&overrides_path).unwrap();
+    assert!(!stored.contains("master-secret"));
+    assert!(!stored.contains("provider-secret"));
+    assert!(stored.contains("tsenc:v1:"));
+
+    let loaded = tokenscavenger::config::overrides::load_runtime_overrides(&temp_config).unwrap();
+    assert_eq!(loaded.server.master_api_key, "master-secret");
+    assert_eq!(
+        loaded.providers[0].api_key.as_deref(),
+        Some("provider-secret")
+    );
+    let _ = std::fs::remove_file(overrides_path);
+}
+
+#[tokio::test]
+async fn test_update_check_reports_disabled_by_default() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    let router = tokenscavenger::app::startup::build_router(AppState::new(
+        Config::default(),
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    ));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/admin/update/check")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), 4096)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["enabled"], false);
+    assert_eq!(json["update_available"], false);
+}
+
+#[tokio::test]
 async fn test_ui_redirects_to_login_when_session_auth_required() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     sqlx::migrate!("src/db/migrations")


### PR DESCRIPTION
## Summary
- completes the Deployment, Security, And Team Controls roadmap item on top of the already-merged role-aware external identity work
- adds encrypted credential persistence for runtime overrides using an operator-supplied AES-GCM key
- adds opt-in self-update check/apply admin API and UI banner with checksum verification and same-args restart
- adds configurable retention windows for usage, health, audit, and request traces
- adds Homebrew formula and Kubernetes manifest starters
- adds release SBOM generation and GitHub artifact provenance attestations
- documents restore drills, rollback flow, update flow, credential encryption, packaging, and verification surfaces

## Context
The earlier release workflow was cancelled before publishing because the first PR only implemented the identity/team-access slice. This PR completes the rest of the roadmap item before release.

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo test --all-features
- pnpm --dir docs build
- git diff --check
- local smoke test for disabled update status and encrypted persisted overrides