### PR TITLE
Fix attested release retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
           fi
 
           if git rev-parse "v$NEW_VER" >/dev/null 2>&1; then
+            if [ "${{ github.event.inputs.bump_type }}" = "current" ]; then
+              echo "Tag v$NEW_VER already exists — reusing for current-version release"
+              exit 0
+            fi
             echo "Tag v$NEW_VER already exists — aborting"
             exit 1
           fi
@@ -187,6 +191,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- grant OIDC and attestation permissions to the release job that runs provenance attestation
- allow a current-version release retry to reuse an existing tag after a failed publish

## Validation
- inspected release workflow diff
- release run 27908783478 built all platform artifacts and failed only at attestation due missing ID token