### PR TITLE
Detect existing remote release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,8 @@ jobs:
             git push origin HEAD:${{ github.ref_name }}
           fi
 
-          if git rev-parse "v$NEW_VER" >/dev/null 2>&1; then
+          if git rev-parse "v$NEW_VER" >/dev/null 2>&1 \
+            || git ls-remote --exit-code --tags origin "refs/tags/v$NEW_VER" >/dev/null 2>&1; then
             if [ "${{ github.event.inputs.bump_type }}" = "current" ]; then
               echo "Tag v$NEW_VER already exists — reusing for current-version release"
               exit 0


### PR DESCRIPTION
## Summary
- make the release prepare step detect an existing remote tag when checkout did not fetch tags
- keep current-version retries able to reuse an existing tag after a failed publish

## Validation
- inspected the failed v0.3.4 retry log from run 27909226402
- verified the failure was a duplicate remote tag push after checkout omitted tags