### PR TITLE
Complete packaging release assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Completed the Homebrew packaging with release artifact checksums and formula
+  validation.
+- Replaced the Kubernetes deployment image placeholder with a concrete local
+  image tag and documented registry retagging for remote clusters.
+
 ## [0.3.4] - 2026-06-21
 
 ### Added

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: tokenscavenger
-          image: ghcr.io/kabudu/token-scavenger:REPLACE_WITH_VERSION
+          image: tokenscavenger:0.3.5
           args: ["--config", "/config/tokenscavenger.toml"]
           ports:
             - name: http

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -65,7 +65,7 @@ CMD ["-c", "/tokenscavenger.toml"]
 Build and run:
 
 ```bash
-docker build -t tokenscavenger .
+docker build -t tokenscavenger:0.3.5 .
 docker run -d \
   --name tokenscavenger \
   -p 8000:8000 \
@@ -73,7 +73,7 @@ docker run -d \
   -v /path/to/data:/data \
   -e GROQ_API_KEY=... \
   -e GEMINI_API_KEY=... \
-  tokenscavenger
+  tokenscavenger:0.3.5
 ```
 
 Or use Docker Compose:
@@ -327,10 +327,21 @@ Ready-to-import monitoring starters live in `monitoring/`:
 Release artifacts also include `checksums.txt`, an SPDX SBOM, and GitHub
 artifact attestations for provenance verification.
 
-## Packaging Starters
+## Packaging
 
-- Homebrew formula template: `packaging/homebrew/tokenscavenger.rb`
+- Homebrew formula: `packaging/homebrew/tokenscavenger.rb`
 - Kubernetes manifests: `deploy/kubernetes/`
+
+The Homebrew formula points at the signed/notarized macOS ARM64 and Linux x86_64
+release artifacts and pins their SHA256 checksums. To distribute through
+`brew install kabudu/tap/tokenscavenger`, publish the formula into a Homebrew tap
+repository such as `kabudu/homebrew-tap`; no Homebrew account signup is required
+for a GitHub-hosted tap.
+
+The Kubernetes deployment references `tokenscavenger:0.3.5`, matching the local
+Docker build tag above. For a remote cluster, retag and push that image to your
+registry, then update `deploy/kubernetes/deployment.yaml` to the registry image
+your cluster can pull.
 
 ### Logging
 

--- a/packaging/homebrew/tokenscavenger.rb
+++ b/packaging/homebrew/tokenscavenger.rb
@@ -1,24 +1,25 @@
 class Tokenscavenger < Formula
   desc "Self-hosted OpenAI-compatible LLM proxy/router"
   homepage "https://github.com/kabudu/token-scavenger"
-  version "0.3.4"
 
   on_macos do
-    if Hardware::CPU.arm?
-      url "https://github.com/kabudu/token-scavenger/releases/download/v#{version}/tokenscavenger-v#{version}-aarch64-apple-darwin.zip"
-      sha256 "REPLACE_WITH_RELEASE_SHA256"
+    on_arm do
+      url "https://github.com/kabudu/token-scavenger/releases/download/v0.3.4/tokenscavenger-v0.3.4-aarch64-apple-darwin.zip"
+      sha256 "438bca5d8cf9a4a97d2c98c566c79319dbb1a3082b7800c72ae3e57e77cd0435"
     end
   end
 
   on_linux do
-    if Hardware::CPU.intel?
-      url "https://github.com/kabudu/token-scavenger/releases/download/v#{version}/tokenscavenger-v#{version}-x86_64-unknown-linux-gnu"
-      sha256 "REPLACE_WITH_RELEASE_SHA256"
+    on_intel do
+      url "https://github.com/kabudu/token-scavenger/releases/download/v0.3.4/tokenscavenger-v0.3.4-x86_64-unknown-linux-gnu"
+      sha256 "c0cb6dbd7347ab9cafd3e42f4b5684b6a06953d9918439361e88644c55a7d459"
     end
   end
 
   def install
     candidate = Dir["tokenscavenger*"].find { |path| File.file?(path) }
+    odie "tokenscavenger release binary was not found" unless candidate
+
     bin.install candidate => "tokenscavenger"
   end
 


### PR DESCRIPTION
## Summary
- Complete the Homebrew formula with real release artifact checksums and formula validation behavior.
- Replace the Kubernetes image placeholder with a concrete local image tag and document registry retagging.
- Update deployment docs and changelog for the packaging cleanup.

## Validation
- `ruby -c packaging/homebrew/tokenscavenger.rb`
- placeholder scan over packaging/deployment docs
- `git diff --check`
- Ruby YAML structural validation for `deploy/kubernetes/*.yaml`
- `brew audit --formula --strict kabudu/tap/tokenscavenger`
- `brew style kabudu/tap/tokenscavenger`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`

`kubectl apply --dry-run=client` was attempted, but this local kubectl still tried API discovery against localhost without a cluster. The manifests were validated structurally with Ruby YAML instead.

## Release note
The source formula pins the currently published v0.3.4 artifacts because Homebrew checksums require existing release assets. After the v0.3.5 release is published, the public `kabudu/homebrew-tap` formula should be updated to the v0.3.5 checksums.