### PR TITLE
Make self-update checks passive by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The release workflow now updates `kabudu/homebrew-tap` automatically after
   publishing release artifacts.
+- Self-update checks are enabled by default and passive check failures now
+  return a diagnostic status instead of disrupting the admin UI.
 
 ### Fixed
 
 - Updated the in-repository Homebrew formula copy to the current v0.3.5 release
   artifact URLs and checksums.
+- Self-update checksum verification now accepts the `dist/...` paths emitted in
+  release `checksums.txt` files.
 
 ## [0.3.5] - 2026-06-21
 

--- a/documentation/api-behavior.md
+++ b/documentation/api-behavior.md
@@ -19,7 +19,7 @@ TokenScavenger exposes OpenAI-compatible HTTP endpoints while routing each reque
 | `GET /admin/incidents` | Incident feed derived from provider health events, route failures, and config audit history. |
 | `GET /admin/diagnostics/bundle` | Redacted diagnostic bundle for support and incident handoff. |
 | `GET /admin/whoami` | Current authenticated admin principal, auth source, role, and credential-management permission. |
-| `GET /admin/update/check` | Self-update status for the configured GitHub release source. |
+| `GET /admin/update/check` | Self-update status for the configured GitHub release source. Network failures return `200 OK` with `update_available = false` and `check_error`. |
 | `POST /admin/update/apply` | Download, checksum-verify, install, and restart onto the latest release when self-update is enabled. |
 
 ## Error Shape

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -51,7 +51,7 @@ audit_days = 90
 request_trace_days = 30
 
 [updates]
-enabled = false                     # Enable admin UI/API self-update checks
+enabled = true                      # Enable admin UI/API self-update checks
 github_repo = "kabudu/token-scavenger"
 check_interval_secs = 21600
 
@@ -209,9 +209,13 @@ variable references there for best hygiene.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `enabled` | `false` | Enables `/admin/update/check`, `/admin/update/apply`, and the admin UI update banner. |
+| `enabled` | `true` | Enables `/admin/update/check`, `/admin/update/apply`, and the admin UI update banner. |
 | `github_repo` | `"kabudu/token-scavenger"` | GitHub repository used for release discovery. |
 | `check_interval_secs` | `21600` | Intended operator polling interval for update checks. |
+
+Update checks are passive and resilient: if GitHub is unreachable or the host
+has no internet access, `/admin/update/check` still returns `200 OK` with
+`update_available = false` and a `check_error` message for diagnostics.
 
 When applying an update, TokenScavenger downloads the platform release asset,
 verifies it against `checksums.txt`, replaces the current executable, and

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -189,7 +189,9 @@ files cannot be restored without the same key.
 
 ### Self-Update
 
-Self-update is opt-in:
+Self-update checks are enabled by default. The check is passive and only shows
+an admin UI CTA when a newer release exists; installing the update still
+requires an explicit operator action.
 
 ```toml
 [updates]
@@ -198,7 +200,9 @@ github_repo = "kabudu/token-scavenger"
 ```
 
 The admin UI checks `/admin/update/check` and displays an update CTA when a
-newer GitHub release exists. Applying an update downloads the matching platform
+newer GitHub release exists. If GitHub is unreachable or the host has no
+internet access, the check returns no update plus a diagnostic `check_error`
+instead of disrupting the UI. Applying an update downloads the matching platform
 asset, verifies it against `checksums.txt`, replaces the current executable, and
 restarts TokenScavenger with the same command-line arguments. Use a process
 manager such as systemd, launchd, Docker, or Kubernetes for additional restart

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -77,7 +77,7 @@ impl Default for RetentionConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateConfig {
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub enabled: bool,
     #[serde(default = "default_update_repo")]
     pub github_repo: String,
@@ -88,7 +88,7 @@ pub struct UpdateConfig {
 impl Default for UpdateConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             github_repo: default_update_repo(),
             check_interval_secs: default_update_check_interval_secs(),
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -15,6 +15,7 @@ pub struct UpdateStatus {
     pub update_available: bool,
     pub release_url: Option<String>,
     pub asset_name: Option<String>,
+    pub check_error: Option<String>,
 }
 
 pub async fn check_for_update(config: &UpdateConfig) -> Result<UpdateStatus, UpdateError> {
@@ -27,10 +28,24 @@ pub async fn check_for_update(config: &UpdateConfig) -> Result<UpdateStatus, Upd
             update_available: false,
             release_url: None,
             asset_name: None,
+            check_error: None,
         });
     }
 
-    let release = fetch_latest_release(config).await?;
+    let release = match fetch_latest_release(config).await {
+        Ok(release) => release,
+        Err(error) => {
+            return Ok(UpdateStatus {
+                enabled: true,
+                current_version: current,
+                latest_version: None,
+                update_available: false,
+                release_url: None,
+                asset_name: platform_asset_name(&format!("v{}", env!("CARGO_PKG_VERSION"))),
+                check_error: Some(error.to_string()),
+            });
+        }
+    };
     let latest = release.tag_name.trim_start_matches('v').to_string();
     let asset_name = platform_asset_name(&release.tag_name);
     let update_available = version_gt(&latest, &current);
@@ -41,6 +56,7 @@ pub async fn check_for_update(config: &UpdateConfig) -> Result<UpdateStatus, Upd
         update_available,
         release_url: Some(release.html_url),
         asset_name,
+        check_error: None,
     })
 }
 
@@ -60,6 +76,7 @@ pub async fn apply_update(state: AppState) -> Result<UpdateStatus, UpdateError> 
             update_available: false,
             release_url: Some(release.html_url),
             asset_name: platform_asset_name(&release.tag_name),
+            check_error: None,
         });
     }
 
@@ -76,7 +93,7 @@ pub async fn apply_update(state: AppState) -> Result<UpdateStatus, UpdateError> 
         .find(|asset| asset.name == "checksums.txt")
         .ok_or(UpdateError::MissingChecksums)?;
 
-    let client = github_client()?;
+    let client = github_asset_client()?;
     let binary_bytes = client
         .get(&asset.browser_download_url)
         .send()
@@ -109,6 +126,7 @@ pub async fn apply_update(state: AppState) -> Result<UpdateStatus, UpdateError> 
         update_available: true,
         release_url: Some(release.html_url),
         asset_name: Some(asset_name),
+        check_error: None,
     })
 }
 
@@ -180,7 +198,7 @@ fn verify_checksum(asset_name: &str, bytes: &[u8], checksums: &str) -> Result<()
             let mut parts = line.split_whitespace();
             let hash = parts.next()?;
             let name = parts.next()?;
-            (name == asset_name).then(|| hash.to_string())
+            name.ends_with(asset_name).then(|| hash.to_string())
         })
         .ok_or_else(|| UpdateError::MissingChecksum(asset_name.to_string()))?;
     let actual = format!("{:x}", Sha256::digest(bytes));
@@ -220,7 +238,7 @@ async fn fetch_latest_release(config: &UpdateConfig) -> Result<GithubRelease, Up
         "https://api.github.com/repos/{}/releases/latest",
         config.github_repo
     );
-    Ok(github_client()?
+    Ok(github_metadata_client()?
         .get(url)
         .send()
         .await?
@@ -229,7 +247,15 @@ async fn fetch_latest_release(config: &UpdateConfig) -> Result<GithubRelease, Up
         .await?)
 }
 
-fn github_client() -> Result<reqwest::Client, UpdateError> {
+fn github_metadata_client() -> Result<reqwest::Client, UpdateError> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .user_agent(format!("tokenscavenger/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(UpdateError::Http)
+}
+
+fn github_asset_client() -> Result<reqwest::Client, UpdateError> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .user_agent(format!("tokenscavenger/{}", env!("CARGO_PKG_VERSION")))
@@ -288,6 +314,14 @@ mod tests {
         let bytes = b"hello";
         let hash = format!("{:x}", Sha256::digest(bytes));
         let checksums = format!("{hash}  artifact");
+        verify_checksum("artifact", bytes, &checksums).unwrap();
+    }
+
+    #[test]
+    fn verifies_matching_checksum_when_release_file_uses_dist_path() {
+        let bytes = b"hello";
+        let hash = format!("{:x}", Sha256::digest(bytes));
+        let checksums = format!("{hash}  dist/artifact/artifact");
         verify_checksum("artifact", bytes, &checksums).unwrap();
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -914,14 +914,17 @@ async fn test_encrypted_runtime_overrides_do_not_store_plaintext_secrets() {
 }
 
 #[tokio::test]
-async fn test_update_check_reports_disabled_by_default() {
+async fn test_update_check_is_enabled_by_default_and_resilient_to_failures() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     sqlx::migrate!("src/db/migrations")
         .run(&pool)
         .await
         .unwrap();
+    let mut config = Config::default();
+    assert!(config.updates.enabled);
+    config.updates.github_repo = "\n".to_string();
     let router = tokenscavenger::app::startup::build_router(AppState::new(
-        Config::default(),
+        config,
         pool,
         Default::default(),
         tokio::sync::broadcast::channel(1).0,
@@ -941,8 +944,9 @@ async fn test_update_check_reports_disabled_by_default() {
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["enabled"], false);
+    assert_eq!(json["enabled"], true);
     assert_eq!(json["update_available"], false);
+    assert!(json["check_error"].as_str().is_some());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Enable self-update checks by default while keeping install/apply as an explicit admin action.
- Make `GET /admin/update/check` resilient to GitHub/network failures by returning a diagnostic status instead of an API error.
- Keep `POST /admin/update/apply` strict for download, checksum, and install failures.
- Fix self-update checksum matching for the `dist/...` paths emitted in release `checksums.txt`.
- Update configuration, API, deployment docs, and changelog.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`

## Notes
The new release should be v0.3.6 and will exercise the release workflow's Homebrew tap update job.