### PR TITLE
Fix Chat Tester default model handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refreshed README and deployment guidance for Homebrew-first installs,
+  self-update testing, and current v0.3.6 deployment examples.
+
 ### Fixed
+
+- Fixed the admin Chat Tester so the `Default` model selection resolves to an
+  enabled discovered chat model instead of sending the literal model `default`.
 
 ## [0.3.6] - 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,19 @@ Error responses use the OpenAI-style `{"error": ...}` envelope. Upstream rate-li
 
 ## Quick Start
 
-### 1. Download the latest release
+### 1. Install TokenScavenger
 
-The simplest way to run TokenScavenger is to download the prebuilt binary for
-your platform from the [latest GitHub release](https://github.com/kabudu/token-scavenger/releases/latest).
+The simplest install path on macOS or Linux with Homebrew is:
+
+```bash
+brew tap kabudu/tap
+brew install tokenscavenger
+tokenscavenger setup
+tokenscavenger -c ~/.config/tokenscavenger/tokenscavenger.toml
+```
+
+You can also download a prebuilt binary for your platform from the
+[latest GitHub release](https://github.com/kabudu/token-scavenger/releases/latest).
 
 Each release includes self-contained binaries and SHA256 checksums. Download the
 matching artifact and start it:
@@ -159,7 +168,8 @@ cargo build --release
 ```
 
 See [documentation/deployment.md](documentation/deployment.md) for Docker,
-systemd, reverse proxy, and cross-compilation options.
+systemd, Kubernetes manifests, reverse proxy, Homebrew tap automation,
+self-update, retention, restore, and migration rollback options.
 
 ### 5. Use it
 
@@ -310,6 +320,18 @@ OIDC-capable reverse proxy such as oauth2-proxy, Dex, Authelia, Keycloak, Zitade
 or a cloud identity proxy. Groups map to read-only, operator, config editor,
 credential manager, and admin roles for the operator UI and admin API.
 
+Self-update is enabled by default in current releases. The admin UI checks
+GitHub releases in the background and shows an update CTA when a newer compatible
+artifact is available for the running platform. Update checks are best-effort:
+network failures never break the admin UI, and the diagnostic error is exposed
+from `/admin/update/check`.
+
+For self-update testing, start from a release that already contains the
+self-update UI and API. Very old binaries, including v0.3.4, predate the admin
+update CTA, so changing `[updates]` in their config cannot make the button
+appear. Use a later pre-v0.3.6 binary or a versioned Homebrew formula when you
+need an older install that can update itself to the latest release.
+
 ## Operator UI
 
 Open `http://localhost:8000/ui` in your browser for the operator dashboard with views for:
@@ -349,12 +371,15 @@ The workflow:
 - Builds binaries for Linux (x86_64), signed/notarized macOS (ARM64), and Windows (x86_64)
 - Creates a GitHub release with all binaries, checksums, an SPDX SBOM, and
   GitHub artifact attestations attached
+- Updates `kabudu/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured with
+  write access to that tap repository
 - Generates release notes from commit history
 
 macOS signing and notarization require these GitHub repository secrets:
 `APPLE_DEVELOPER_ID_CERTIFICATE_BASE64`,
 `APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD`, `APPLE_CODESIGN_IDENTITY`,
 `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD`.
+Homebrew tap publishing requires `HOMEBREW_TAP_TOKEN`.
 
 Each release binary is self-contained — download the one for your platform and run
 it. On first execution the built-in setup wizard guides you through configuration.

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: tokenscavenger
-          image: tokenscavenger:0.3.5
+          image: tokenscavenger:0.3.6
           args: ["--config", "/config/tokenscavenger.toml"]
           ports:
             - name: http

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -65,7 +65,7 @@ CMD ["-c", "/tokenscavenger.toml"]
 Build and run:
 
 ```bash
-docker build -t tokenscavenger:0.3.5 .
+docker build -t tokenscavenger:0.3.6 .
 docker run -d \
   --name tokenscavenger \
   -p 8000:8000 \
@@ -73,7 +73,7 @@ docker run -d \
   -v /path/to/data:/data \
   -e GROQ_API_KEY=... \
   -e GEMINI_API_KEY=... \
-  tokenscavenger:0.3.5
+  tokenscavenger:0.3.6
 ```
 
 Or use Docker Compose:
@@ -343,7 +343,7 @@ updates `kabudu/homebrew-tap` after publishing a release by reading the generate
 branch. That cross-repository push requires a repository secret named
 `HOMEBREW_TAP_TOKEN` with `contents:write` access to `kabudu/homebrew-tap`.
 
-The Kubernetes deployment references `tokenscavenger:0.3.5`, matching the local
+The Kubernetes deployment references `tokenscavenger:0.3.6`, matching the local
 Docker build tag above. For a remote cluster, retag and push that image to your
 registry, then update `deploy/kubernetes/deployment.yaml` to the registry image
 your cluster can pull.

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -161,7 +161,7 @@ You should see:
  INFO tokenscavenger: Config loaded from tokenscavenger.toml: server.bind=0.0.0.0:8000, providers=3
  INFO tokenscavenger: Database initialized at tokenscavenger.db
  INFO tokenscavenger: AppState created
- INFO tokenscavenger: TokenScavenger v0.1.2 starting on 0.0.0.0:8000
+ INFO tokenscavenger: TokenScavenger v0.3.6 starting on 0.0.0.0:8000
 ```
 
 ## Step 5: Test

--- a/src/ui/routes.rs
+++ b/src/ui/routes.rs
@@ -1996,7 +1996,7 @@ pub async fn render_chat(state: &AppState) -> String {
     function onProviderChange() {{
         const prov = providerSel.value;
         modelSel.innerHTML = '<option value="">Default</option>';
-        const filtered = prov ? allModels.filter(m => m.provider_id === prov && m.enabled !== false) : allModels.filter(m => m.enabled !== false);
+        const filtered = modelsForCurrentSelection();
         filtered.forEach(m => {{
             const opt = document.createElement('option');
             opt.value = m.upstream_model_id || '';
@@ -2004,6 +2004,23 @@ pub async fn render_chat(state: &AppState) -> String {
             modelSel.appendChild(opt);
         }});
     }}
+
+    function modelsForCurrentSelection() {{
+        const prov = providerSel.value;
+        return allModels.filter(m =>
+            m.enabled !== false &&
+            m.supports_chat !== false &&
+            (!prov || m.provider_id === prov)
+        );
+    }}
+
+    function resolveSelectedModel() {{
+        const explicit = modelSel.value;
+        if (explicit) return explicit;
+        const fallback = modelsForCurrentSelection()[0];
+        return fallback?.upstream_model_id || fallback?.public_model_id || '';
+    }}
+
     onProviderChange();
 
     let messages = []; // {{role, content}}
@@ -2051,7 +2068,11 @@ pub async fn render_chat(state: &AppState) -> String {
         const userText = input.value.trim();
         if (!userText) return;
 
-        const model = modelSel.value || undefined;
+        const model = resolveSelectedModel();
+        if (!model) {{
+            setStatus('No enabled chat models are available for the current provider filter.');
+            return;
+        }}
         const systemPrompt = document.getElementById('systemPrompt').value.trim();
         const temperature = parseFloat(document.getElementById('temperature').value);
         const maxTokens = parseInt(document.getElementById('maxTokens').value, 10);
@@ -2075,7 +2096,7 @@ pub async fn render_chat(state: &AppState) -> String {
         const t0 = Date.now();
         try {{
             const body = {{
-                model: model || 'default',
+                model,
                 messages: reqMessages,
                 temperature,
                 max_tokens: maxTokens,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -950,6 +950,42 @@ async fn test_update_check_is_enabled_by_default_and_resilient_to_failures() {
 }
 
 #[tokio::test]
+async fn test_chat_tester_default_resolves_to_discovered_model() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("src/db/migrations")
+        .run(&pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO providers (provider_id, display_name, enabled, free_only)
+         VALUES ('local', 'Local', 1, 1)",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO models
+         (provider_id, upstream_model_id, public_model_id, enabled, free_tier, supports_chat, supports_embeddings, discovered_at, updated_at)
+         VALUES ('local', 'llama3.2', 'llama3.2', 1, 1, 1, 0, datetime('now'), datetime('now'))",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let state = AppState::new(
+        Config::default(),
+        pool,
+        Default::default(),
+        tokio::sync::broadcast::channel(1).0,
+    );
+    let html = tokenscavenger::ui::routes::render_chat(&state).await;
+
+    assert!(html.contains("function resolveSelectedModel()"));
+    assert!(html.contains("const model = resolveSelectedModel();"));
+    assert!(!html.contains("model: model || 'default'"));
+}
+
+#[tokio::test]
 async fn test_ui_redirects_to_login_when_session_auth_required() {
     let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
     sqlx::migrate!("src/db/migrations")


### PR DESCRIPTION
## Summary
- Resolve the Chat Tester `Default` model selection to an enabled discovered chat model instead of sending the literal model `default`.
- Add regression coverage for the rendered Chat Tester request construction.
- Refresh README/deployment docs for Homebrew-first installs, self-update testing, release token requirements, and current v0.3.6 deployment examples.

## Why
Selecting a provider while leaving Model as `Default` could send `model: "default"`, causing route exhaustion even when the provider had usable discovered models.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`

## Notes
No `.dev` files are included.